### PR TITLE
Writing support and proper symlink handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,16 @@ matrix:
     - env: LANGUAGE=Rust CLIPPY=true
       language: rust
       rust: nightly
+    - env: LANGUAGE=Ruby DEPLOY=true DEPLOY_FILE="$TRAVIS_BUILD_DIR/../http-man-$TRAVIS_TAG.tbz2"
+      language: ruby
+      rust: []
+      rvm: "2.2"
   allow_failures:
     - rust: beta
     - rust: nightly
+
+install:
+  - if [ "$LANGUAGE" == "Ruby" ]; then gem install ronn; fi
 
 script:
   - if [ "$LANGUAGE" == "Rust" ]; then cargo build --verbose; fi
@@ -28,11 +35,25 @@ script:
       cargo install-update -a;
       cargo clippy;
     fi
+  -
+  - if [ "$LANGUAGE" == "Ruby" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ]; then
+      mkdir man; pushd man;
+      cp ../http.md .;
+      ronn --organization="http developers" http.md;
+      popd;
+    fi
 
 after_success:
   - if [ "$LANGUAGE" == "Rust" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ]; then
       cp target/release/http "$DEPLOY_FILE";
       strip --strip-all --remove-section=.comment --remove-section=.note "$DEPLOY_FILE";
+    fi
+  - if [ "$LANGUAGE" == "Ruby" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ]; then
+      cp -r man "$TRAVIS_BUILD_DIR/../http-man-$TRAVIS_TAG";
+      pushd "$TRAVIS_BUILD_DIR/..";
+      tar -caf "http-man-$TRAVIS_TAG.tbz2" "http-man-$TRAVIS_TAG";
+      rm -rf "http-man-$TRAVIS_TAG";
+      popd;
     fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: cargo
 
 matrix:
   include:
-    - env: LANGUAGE=Rust DEPLOY=true DEPLOY_FILE="$TRAVIS_BUILD_DIR/../https-$TRAVIS_TAG"
+    - env: LANGUAGE=Rust DEPLOY=true DEPLOY_FILE="$TRAVIS_BUILD_DIR/../http-$TRAVIS_TAG"
       language: rust
       rust: stable
     - env: LANGUAGE=Rust
@@ -13,9 +13,6 @@ matrix:
     - env: LANGUAGE=Rust CLIPPY=true
       language: rust
       rust: nightly
-    - env: LANGUAGE=Rust-doc DEPLOY=true DEPLOY_FILE="$TRAVIS_BUILD_DIR/../https-doc-$TRAVIS_TAG.tbz2"
-      language: rust
-      rust: stable
   allow_failures:
     - rust: beta
     - rust: nightly
@@ -24,7 +21,7 @@ script:
   - if [ "$LANGUAGE" == "Rust" ]; then cargo build --verbose; fi
   - if [ "$LANGUAGE" == "Rust" ]; then cargo test  --verbose; fi
   -
-  - if [ "$LANGUAGE" == "Rust" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then cargo build --verbose --release; fi
+  - if [ "$LANGUAGE" == "Rust" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ]; then cargo build --verbose --release; fi
   - if [ "$LANGUAGE" == "Rust" ] && [ "$CLIPPY" ]; then
       cargo install clippy;
       cargo install cargo-update;
@@ -33,17 +30,9 @@ script:
     fi
 
 after_success:
-  - if [ "$LANGUAGE" == "Rust" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
-      cp target/release/https "$DEPLOY_FILE";
+  - if [ "$LANGUAGE" == "Rust" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ]; then
+      cp target/release/http "$DEPLOY_FILE";
       strip --strip-all --remove-section=.comment --remove-section=.note "$DEPLOY_FILE";
-    fi
-  - if [ "$LANGUAGE" == "Rust-doc" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
-      cargo doc;
-      cp -r target/doc "$TRAVIS_BUILD_DIR/../https-doc-$TRAVIS_TAG";
-      pushd "$TRAVIS_BUILD_DIR/..";
-      tar -caf "https-doc-$TRAVIS_TAG.tbz2" "https-doc-$TRAVIS_TAG";
-      rm -rf "https-doc-$TRAVIS_TAG";
-      popd;
     fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: cargo
 
 matrix:
   include:
-    - env: LANGUAGE=Rust DEPLOY=true DEPLOY_FILE="$TRAVIS_BUILD_DIR/../rtffs-$TRAVIS_TAG"
+    - env: LANGUAGE=Rust DEPLOY=true DEPLOY_FILE="$TRAVIS_BUILD_DIR/../https-$TRAVIS_TAG"
       language: rust
       rust: stable
     - env: LANGUAGE=Rust
@@ -13,7 +13,7 @@ matrix:
     - env: LANGUAGE=Rust CLIPPY=true
       language: rust
       rust: nightly
-    - env: LANGUAGE=Rust-doc DEPLOY=true DEPLOY_FILE="$TRAVIS_BUILD_DIR/../rtffs-doc-$TRAVIS_TAG.tbz2"
+    - env: LANGUAGE=Rust-doc DEPLOY=true DEPLOY_FILE="$TRAVIS_BUILD_DIR/../https-doc-$TRAVIS_TAG.tbz2"
       language: rust
       rust: stable
   allow_failures:
@@ -23,6 +23,7 @@ matrix:
 script:
   - if [ "$LANGUAGE" == "Rust" ]; then cargo build --verbose; fi
   - if [ "$LANGUAGE" == "Rust" ]; then cargo test  --verbose; fi
+  -
   - if [ "$LANGUAGE" == "Rust" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then cargo build --verbose --release; fi
   - if [ "$LANGUAGE" == "Rust" ] && [ "$CLIPPY" ]; then
       cargo install clippy;
@@ -33,15 +34,15 @@ script:
 
 after_success:
   - if [ "$LANGUAGE" == "Rust" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
-      cp target/release/rtffs "$TRAVIS_BUILD_DIR/../rtffs-$TRAVIS_TAG";
-      strip --strip-all --remove-section=.comment --remove-section=.note "$TRAVIS_BUILD_DIR/../rtffs-$TRAVIS_TAG";
+      cp target/release/https "$DEPLOY_FILE";
+      strip --strip-all --remove-section=.comment --remove-section=.note "$DEPLOY_FILE";
     fi
   - if [ "$LANGUAGE" == "Rust-doc" ] && [ "$DEPLOY" ] && [ "$TRAVIS_TAG" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
       cargo doc;
-      cp -r target/doc "$TRAVIS_BUILD_DIR/../rtffs-doc-$TRAVIS_TAG";
+      cp -r target/doc "$TRAVIS_BUILD_DIR/../https-doc-$TRAVIS_TAG";
       pushd "$TRAVIS_BUILD_DIR/..";
-      tar -caf "rtffs-doc-$TRAVIS_TAG.tbz2" "rtffs-doc-$TRAVIS_TAG";
-      rm -rf "rtffs-doc-$TRAVIS_TAG";
+      tar -caf "https-doc-$TRAVIS_TAG.tbz2" "https-doc-$TRAVIS_TAG";
+      rm -rf "https-doc-$TRAVIS_TAG";
       popd;
     fi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/thecoshman/http"
 readme = "README.md"
 keywords = ["http", "server", "https", "file", "directory"]
 license = "MIT"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["thecoshman <thecoshman@gmail.com>",
            "nabijaczleweli <nabijaczleweli@gmail.com>"]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # http [![Build status](https://travis-ci.org/thecoshman/http.svg)](https://travis-ci.org/thecoshman/http) [![Licence](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE) [![Crates.io version](http://meritbadge.herokuapp.com/https)](https://crates.io/crates/https)
 Host These Things Please - a basic HTTP server for hosting a folder fast and simply
 
+## Selected features
+
+See [the manpage](http.md) for full list.
+
+  * [x] Optional following of symlinks (`-s` option)
+  * [x] Index generation for directories (all for now)
+  * [x] Sane defaults (like hosted dir (`.`) and port (forst free one from range `8000`-`9999`))
+  * [x] Correct MIME type for served files
+  * [x] Handled request methods: OPTIONS, GET, PUT, DELETE, HEAD and TRACE ("writing" methods are off by default, enable via `-w` switch)
+  * [x] Proper handling of percent-encoded URLs (like `асдф fdsa`)
+  * [x] Good symlink handling compatible with Windows
+
+## [Manpage](http.md)
+
 ## Aims
 The idea is to make a program that can compile down to a simple binary that can be used via Linux CLI to quickly take the current directory and serve it over HTTP. Everything should have sensible defaults such that you do not *have* to pass parameters like what port to use.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# http [![Build status](https://travis-ci.org/thecoshman/http.svg?branch=master)](https://travis-ci.org/thecoshman/http) [![Licence](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE) [![Crates.io version](http://meritbadge.herokuapp.com/https)](https://crates.io/crates/https)
+# http [![Build status](https://travis-ci.org/thecoshman/http.svg)](https://travis-ci.org/thecoshman/http) [![Licence](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE) [![Crates.io version](http://meritbadge.herokuapp.com/https)](https://crates.io/crates/https)
 Host These Things Please - a basic HTTP server for hosting a folder fast and simply
 
 ## Aims

--- a/assets/directory_listing.html
+++ b/assets/directory_listing.html
@@ -11,12 +11,15 @@
         margin-top: 0;
         margin-bottom: 0;
       }
+
+      p.pre-list {
+        margin-bottom: 0;
+      }
     </style>
   </head>
   <body>
-    <p></p>
     <div>
-      The requested directory {0} contains the following files:
+      <p class="pre-list">The requested directory {0} contains the following files:</p>
       <ul>
         {1}
       </ul>

--- a/assets/directory_listing.html
+++ b/assets/directory_listing.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Directory listing of {0}">
     <title>Directory listing — {0}</title>
     <style type="text/css">
-      ul, ol {
+      ul {
         margin-top: 0;
         margin-bottom: 0;
       }

--- a/http.md
+++ b/http.md
@@ -1,0 +1,148 @@
+http(1) -- a basic HTTP server for hosting a folder fast and simply
+===================================================================
+
+## SYNOPSIS
+
+`http` [OPTIONS] [DIRECTORY]
+
+## DESCRIPTION
+
+Host These Things Please - a basic HTTP server for hosting a folder fast and
+simply.
+
+The idea is to make a program that can compile down to a simple binary that can
+be used via Linux CLI to quickly take the current directory and serve it over
+HTTP. Everything should have sensible defaults such that you do not *have* to
+pass parameters like what port to use.
+
+## OPTIONS
+
+  [DIR]
+
+    Directory to host. Must exist.
+
+    Default: current working directory.
+
+  -p --port [PORT]
+
+    Port to host the server on.
+
+    Must be between 1 and 65'535. Value of 0 will assign a random port,
+    chosen by the OS.
+
+    Default: first free port from 8000 up.
+
+  -t --temp-dir [TEMP]
+
+    Temporary directory to use to store data to write.
+
+    Only matters if --allow-write is also specified.
+
+    Default: $TEMP.
+
+  -s --follow-symlinks
+
+    Follow symlinks when requesting file access.
+
+    This is false by default because it is most likely a problem (according to
+    thecoshman anyway).
+
+    If a symlink is requested and this is not on it will be treated as if it
+    didn't exist.
+
+  -w --allow-write
+
+    Allow for write operations.
+
+    Currently supported write operations: PUT and DELETE.
+
+    This is false by default because it's most likely not something you
+    want to do.
+
+## EXAMPLES
+
+  `http`
+
+    Host the current directory on the first free port upwards of 8000,
+    don't follow symlinks, don't allow writes.
+
+    Example output:
+      p:\Rust\http> http
+      Hosting "." on port 8000...
+      Ctrl-C to stop.
+
+      127.0.0.1:47880 was served directory listing for \\?\P:\Rust\http
+      127.0.0.1:47902 was served file \\?\P:\Rust\http\http.1.html as text/html
+      127.0.0.1:47916 requested to GET nonexistant entity S:\Rust-target\doc\main.css
+      127.0.0.1:48049 asked for options
+      127.0.0.1:47936 used disabled request method DELETE
+      127.0.0.1:48222 used disabled request method PUT
+      ^C
+
+    Assuming that `P:\Rust\http\target` is a symlink to `S:\Rust-target`,
+    the following requests have been made, in order:
+
+      GET /
+      GET /http.1.html
+      GET /target/doc/main.css
+      OPTIONS
+      DELETE <path doesn't matter>
+      PUT <path doesn't matter>
+
+    The above output snippet is used as a reference for other examples.
+
+  `http -s`
+
+    As in the first example, but follow symlinks.
+
+    Example output change:
+      127.0.0.1:47916 was served file S:\Rust-target\doc\main.css as text/css
+
+  `http -w`
+
+    As in the first example, but allow writes.
+
+    Example output change:
+      127.0.0.1:47936 deleted file \\?\P:\Rust\http\http.1.html
+      127.0.0.1:48222 created \\?\P:\Rust\http\index.html, size: 1033554B
+
+    Corresponding request:
+      DELETE /http.1.html
+      PUT /index.html with request body containing roughly 1MB of data
+
+    Another behavioral change is that, in this case, the folder (and file)
+    named "T:/-=- TEMP -=-/http-P-Rust-http/" and
+    "T:/-=- TEMP -=-/http-P-Rust-http/index.html" were created while the file
+    "P:\Rust\http\http.1.html" was deleted (also works on directories).
+
+  `http -w -t "../TEMP"`
+
+    As in the previous example, but use a different temp dir.
+
+    Behavioral changes: the created folder and file are
+    named "P:/Rust/TEMP/http-P-Rust-http/" and
+    "P:/Rust/TEMP/http-P-Rust-http/index.html".
+
+  `http -p 6969`
+
+    As in the first example, but host on port 6969.
+
+    Assuming the port is free, example output change:
+      Hosting "." on port 6969...
+
+    If the port is taken, example output change:
+      Starting server failed: port taken.
+      <EOF>
+
+## AUTHOR
+
+Written by thecoshman &lt;<thecoshman@gmail.com>&gt;,
+       and nabijaczleweli &lt;<nabijaczleweli@gmail.com>&gt;.
+
+## REPORTING BUGS
+
+&lt;<https://github.com/thecoshman/http/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/thecoshman/http>&gt;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -160,8 +160,23 @@ impl HttpHandler {
 }
 
 
+/// Attempt to start a server on ports from `from` to `up_to`, inclusive, with the specified handler.
+///
+/// If an error other than the port being full is encountered it is returned.
+///
+/// If all ports from the range are not free an error is returned.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate https;
+/// # extern crate iron;
+/// # use https::ops::try_ports;
+/// # use iron::{status, Response};
+/// let server = try_ports(|req| Ok(Response::with((status::Ok, "Abolish the burgeoisie!"))), 8000, 8100).unwrap();
+/// ```
 pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16) -> Result<Listening, Error> {
-    for port in from..up_to {
+    for port in from..up_to + 1 {
         match Iron::new(hndlr.clone()).http(("0.0.0.0", port)) {
             Ok(server) => return Ok(server),
             Err(error) => {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -31,7 +31,6 @@ impl Handler for HttpHandler {
         match req.method {
             method::Options => self.handle_options(req),
             method::Get => self.handle_get(req),
-            method::Post => self.handle_post(req),
             method::Put => self.handle_put(req),
             method::Delete => self.handle_delete(req),
             method::Head => {
@@ -130,16 +129,6 @@ impl HttpHandler {
                 };
                 cur + "<li><a href=\"" + &format!("/{}", relpath).replace("//", "/") + &fname + "\">" + &fname + "</a></li>\n"
             })]))))
-    }
-
-    fn handle_post(&self, req: &mut Request) -> IronResult<Response> {
-        if self.temp_directory.is_none() {
-            return self.handle_bad_method(req);
-        }
-
-        self.create_temp_dir();
-        println!("{} requested POST (unhandled, serving 501)", req.remote_addr);
-        self.handle_bad_method(req)
     }
 
     fn handle_put(&self, req: &mut Request) -> IronResult<Response> {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -41,7 +41,6 @@ impl Handler for HttpHandler {
                 })
             }
             method::Trace => self.handle_trace(req),
-            method::Patch => self.handle_patch(req),
             _ => self.handle_bad_method(req),
         }
     }
@@ -242,16 +241,6 @@ impl HttpHandler {
             extensions: TypeMap::new(),
             body: None,
         })
-    }
-
-    fn handle_patch(&self, req: &mut Request) -> IronResult<Response> {
-        if self.temp_directory.is_none() {
-            return self.handle_bad_method(req);
-        }
-
-        self.create_temp_dir();
-        println!("{} requested PATCH (unhandled, serving 501)", req.remote_addr);
-        self.handle_bad_method(req)
     }
 
     fn handle_bad_method(&self, req: &mut Request) -> IronResult<Response> {

--- a/src/options.rs
+++ b/src/options.rs
@@ -13,6 +13,7 @@
 
 use clap::{AppSettings, App, Arg};
 use std::path::PathBuf;
+use std::env::temp_dir;
 use std::str::FromStr;
 use std::fs;
 
@@ -26,6 +27,8 @@ pub struct Options {
     pub port: Option<u16>,
     /// Whether to allow symlinks to be requested. Default: false
     pub follow_symlinks: bool,
+    /// The temp directory to write to before copying to hosted directory. Default: `None`
+    pub temp_directory: Option<(String, PathBuf)>,
 }
 
 impl Options {
@@ -36,24 +39,50 @@ impl Options {
             .author(crate_authors!())
             .setting(AppSettings::ColoredHelp)
             .about("Host These Things Please - a basic HTTP server for hosting a folder fast and simply")
-            .arg(Arg::from_usage("[DIR] 'Directory to host. Default: current working directory'").validator(Options::filesystem_dir_validator))
+            .arg(Arg::from_usage("[DIR] 'Directory to host. Default: current working directory'")
+                .validator(|s| Options::filesystem_dir_validator(s, "Directory to host")))
             .arg(Arg::from_usage("-p --port [port] 'Port to use. Default: first free port from 8000 up'").validator(Options::u16_validator))
+            .arg(Arg::from_usage("--temp-dir [temp] 'Temporary directory. Default: $TEMP'")
+                .validator(|s| Options::filesystem_dir_validator(s, "Temporary directory")))
             .arg(Arg::from_usage("-s --follow-symlinks 'Follow symlinks. Default: false'"))
+            .arg(Arg::from_usage("-w --allow-write 'Allow for write operations. Default: false'"))
             .get_matches();
 
         let dir = matches.value_of("DIR").unwrap_or(".");
+        let dir_pb = fs::canonicalize(dir).unwrap();
         Options {
-            hosted_directory: (dir.to_string(), fs::canonicalize(dir).unwrap()),
+            hosted_directory: (dir.to_string(), dir_pb.clone()),
             port: matches.value_of("port").map(u16::from_str).map(Result::unwrap),
             follow_symlinks: matches.is_present("follow-symlinks"),
+            temp_directory: if matches.is_present("allow-write") {
+                let (temp_s, temp_pb) = if let Some(tmpdir) = matches.value_of("temp-dir") {
+                    (tmpdir.to_string(), fs::canonicalize(tmpdir).unwrap())
+                } else {
+                    ("$TEMP".to_string(), temp_dir())
+                };
+                let suffix = format!("http-{}",
+                                     dir_pb.into_os_string().to_str().unwrap().replace(r"\\?\", "").replace(':', "").replace('\\', "/").replace('/', "-"));
+
+                Some((format!("{}{}{}",
+                              temp_s,
+                              if temp_s.ends_with("/") || temp_s.ends_with(r"\") {
+                                  ""
+                              } else {
+                                  "/"
+                              },
+                              suffix),
+                      temp_pb.join(suffix)))
+            } else {
+                None
+            },
         }
     }
 
-    fn filesystem_dir_validator(s: String) -> Result<(), String> {
-        fs::canonicalize(&s).map_err(|_| format!("Directory to host \"{}\" not found", s)).and_then(|f| if f.is_dir() {
+    fn filesystem_dir_validator(s: String, prefix: &str) -> Result<(), String> {
+        fs::canonicalize(&s).map_err(|_| format!("{} \"{}\" not found", prefix, s)).and_then(|f| if f.is_dir() {
             Ok(())
         } else {
-            Err(format!("Directory to host \"{}\" not actualy a directory", s))
+            Err(format!("{} \"{}\" not actualy a directory", prefix, s))
         })
     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -42,7 +42,7 @@ impl Options {
             .arg(Arg::from_usage("[DIR] 'Directory to host. Default: current working directory'")
                 .validator(|s| Options::filesystem_dir_validator(s, "Directory to host")))
             .arg(Arg::from_usage("-p --port [port] 'Port to use. Default: first free port from 8000 up'").validator(Options::u16_validator))
-            .arg(Arg::from_usage("--temp-dir [temp] 'Temporary directory. Default: $TEMP'")
+            .arg(Arg::from_usage("-t --temp-dir [temp] 'Temporary directory. Default: $TEMP'")
                 .validator(|s| Options::filesystem_dir_validator(s, "Temporary directory")))
             .arg(Arg::from_usage("-s --follow-symlinks 'Follow symlinks. Default: false'"))
             .arg(Arg::from_usage("-w --allow-write 'Allow for write operations. Default: false'"))

--- a/src/util.rs
+++ b/src/util.rs
@@ -127,3 +127,33 @@ pub fn file_time_modified(f: &Path) -> Tm {
         Err(ste) => time::now() + Duration::from_std(ste.duration()).unwrap(),
     }
 }
+
+/// Check, whether, in any place of the path, a file is treated like a directory.
+///
+/// A file is treated like a directory when it is treated as if it had a subpath, e.g., given:
+///
+/// ```sh
+/// tree .
+/// | dir0
+/// | dir1
+///   | file01
+/// ```
+///
+/// This function would return true for `./dir1/file01/file010`, `./dir1/file01/dir010/file0100`, etc., but not
+/// for `./dir0/file00`, `./dir0/dir00/file000`, `./dir1/file02/`, `./dir1/dir010/file0100`.
+pub fn detect_file_as_dir(mut p: &Path) -> bool {
+    while let Some(pnt) = p.parent() {
+        if pnt.is_file() {
+            return true;
+        }
+
+        p = pnt;
+    }
+
+    false
+}
+
+/// Check if a path refers to a symlink in a way that also works on Windows.
+pub fn is_symlink<P: AsRef<Path>>(p: P) -> bool {
+    p.as_ref().read_link().is_ok()
+}


### PR DESCRIPTION
Support for write requests (+collateral) is done now, and here's the rundown:

  * [x] `-w` switch to enable writing [1]
  * [x] temp dir where files to write are stored (default: `$TEMP/http-<hosted dir>`), configurable via `-t` switch
  * [x] PUT request writes the file to the temp dir then copies it to the hosted dir
  * [ ] POST requests have been withdrawn, because the only relevant usage to us is already covered by PUT (#12)
  * [x] Symlinks are now handled in a better and Windows-compatible fashion
  * [ ] PATCH requests have been withdrawn, because of open-endedness of standard wording (#13)
  * [x] DELETE requests delete files and directories just as eagerly [2]

[1] We return 501 Not Implemented when doing a write-class request and writing is not on. I think we might want to change that. What do you think?
[2] Should we copy the deleted things to the temp dir before we delete them?

Closes #25

<sub>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</sub>