### PR TITLE
Sane symlinks and improved logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/thecoshman/http"
 readme = "README.md"
 keywords = ["http", "server", "https", "file", "directory"]
 license = "MIT"
-version = "0.3.1"
+version = "1.0.0"
 authors = ["thecoshman <thecoshman@gmail.com>",
            "nabijaczleweli <nabijaczleweli@gmail.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ time = "0.1"
 url = "1.2"
 md6 = "1.1"
 
+[dependencies.trivial_colours]
+version = "0.2"
+default-features = false
+
 
 [[bin]]
 name = "http"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Host These Things Please - a basic HTTP server for hosting a folder fast and sim
 
 See [the manpage](http.md) for full list.
 
-  * [x] Optional following of symlinks (`-s` option)
+  * [x] Symlinks followed by default (disableable via `-s` option)
   * [x] Index generation for directories
-  * [x] Sane defaults (like hosted dir (`.`) and port (forst free one from range `8000`-`9999`))
+  * [x] Sane defaults (like hosted dir (`.`) and port (first free one from range `8000`-`9999`))
   * [x] Correct MIME type for served files
   * [x] Handled request methods: OPTIONS, GET, PUT, DELETE, HEAD and TRACE ("writing" methods are off by default, enable via `-w` switch)
   * [x] Proper handling of percent-encoded URLs (like `асдф fdsa`)
@@ -23,7 +23,7 @@ See [the manpage](http.md) for full list.
 The idea is to make a program that can compile down to a simple binary that can be used via Linux CLI to quickly take the current directory and serve it over HTTP. Everything should have sensible defaults such that you do not *have* to pass parameters like what port to use.
 
   * [x] Sub directories would be automatically hosted.
-  * [x] Symlinks will not be followed by default (in my opinion, this is more likely to be a problem than an intended thing).
+  * [ ] Symlinks will not be followed by default (in my opinion, this is more likely to be a problem than an intended thing).
   * [x] Root should not be required.
   * [x] If an index file isn't provided, one will be generated (in memory, no touching the disk, why would you do that you dirty freak you), that will list the current files and folders (and then sub directories will have index files generated as required)
   * [x] Changes made to files should be reflected instantly, as I don't see why anything would be cached... you request a file, a file will be looked for

--- a/http.md
+++ b/http.md
@@ -40,15 +40,12 @@ pass parameters like what port to use.
 
     Default: $TEMP.
 
-  -s --follow-symlinks
+  -s --no-follow-symlinks
 
-    Follow symlinks when requesting file access.
+    Don't follow symlinks when requesting file access.
 
-    This is false by default because it is most likely a problem (according to
-    thecoshman anyway).
-
-    If a symlink is requested and this is not on it will be treated as if it
-    didn't exist.
+    If a symlink is requested and this is on it will be treated as if it didn't
+    exist.
 
   -w --allow-write
 
@@ -89,7 +86,7 @@ pass parameters like what port to use.
 
       127.0.0.1:47880 was served directory listing for \\?\P:\Rust\http
       127.0.0.1:47902 was served file \\?\P:\Rust\http\http.1.html as text/html
-      127.0.0.1:47916 requested to GET nonexistant entity S:\Rust-target\doc\main.css
+      127.0.0.1:47916 was served file S:\Rust-target\doc\main.css as text/css
       127.0.0.1:48049 asked for options
       127.0.0.1:47936 used disabled request method DELETE
       127.0.0.1:48222 used disabled request method PUT
@@ -109,10 +106,10 @@ pass parameters like what port to use.
 
   `http -s`
 
-    As in the first example, but follow symlinks.
+    As in the first example, but don't follow symlinks.
 
     Example output change:
-      127.0.0.1:47916 was served file S:\Rust-target\doc\main.css as text/css
+      127.0.0.1:47916 requested to GET nonexistant entity S:\Rust-target\doc\main.css
 
   `http -w`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+extern crate trivial_colours;
 #[macro_use]
 extern crate lazy_static;
 extern crate mime_guess;
@@ -58,7 +59,7 @@ fn result_main() -> Result<(), Error> {
         ops::try_ports(ops::HttpHandler::new(&opts), util::PORT_SCAN_LOWEST, util::PORT_SCAN_HIGHEST)
     });
 
-    println!("Hosting \"{}\" on port {}...", opts.hosted_directory.0, responder.socket.port());
+    println!("{}Hosting \"{}\" on port {}...", trivial_colours::Reset, opts.hosted_directory.0, responder.socket.port());
     println!("Ctrl-C to stop.");
     println!();
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -249,7 +249,7 @@ impl HttpHandler {
                     let r = self.handle_get_file(req, idx);
                     log!("{} found index file for directory {}{}{}",
                          iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
-                         C::Magenta
+                         C::Magenta,
                          req_p.display(),
                          CReset);
                     return r;
@@ -268,7 +268,7 @@ impl HttpHandler {
              C::Green,
              req.remote_addr,
              CReset,
-             C::Green,
+             C::Yellow,
              new_url,
              CReset,
              C::Magenta,
@@ -511,7 +511,15 @@ impl HttpHandler {
     }
 
     fn handle_trace(&self, req: &mut Request) -> IronResult<Response> {
-        log!("{}{}{} requested {}TRACE{} for {}{}{}", C::Green, req.remote_addr, CReset, C::Red, CReset, C::Magenta, url_path(&req.url), CReset);
+        log!("{}{}{} requested {}TRACE{} for {}{}{}",
+             C::Green,
+             req.remote_addr,
+             CReset,
+             C::Red,
+             CReset,
+             C::Magenta,
+             url_path(&req.url),
+             CReset);
 
         let mut hdr = req.headers.clone();
         hdr.set(headers::ContentType("message/http".parse().unwrap()));

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,7 +1,6 @@
 use md6;
-use std::io;
-use std::iter;
-use time::strftime;
+use time::now;
+use std::{iter, io};
 use iron::mime::Mime;
 use std::sync::RwLock;
 use lazysort::SortedBy;
@@ -16,6 +15,18 @@ use iron::{headers, status, method, mime, IronResult, Listening, Response, TypeM
 use self::super::util::{url_path, file_hash, is_symlink, encode_str, encode_file, hash_string, html_response, file_binary, percent_decode, response_encoding,
                         detect_file_as_dir, encoding_extension, file_time_modified, human_readable_size, USER_AGENT, ERROR_HTML, INDEX_EXTENSIONS,
                         MAX_ENCODING_SIZE, MIN_ENCODING_SIZE, DIRECTORY_LISTING_HTML};
+
+
+macro_rules! log {
+    ($fmt:expr) => {
+        print!("[{}] ", now().strftime("%F %T").unwrap());
+        println!($fmt);
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        print!("[{}] ", now().strftime("%F %T").unwrap());
+        println!($fmt, $($arg)*);
+    };
+}
 
 
 // TODO: ideally this String here would be Encoding instead but hyper is bad
@@ -83,7 +94,7 @@ impl Handler for HttpHandler {
 
 impl HttpHandler {
     fn handle_options(&self, req: &mut Request) -> IronResult<Response> {
-        println!("{} asked for options", req.remote_addr);
+        log!("{} asked for options", req.remote_addr);
         Ok(Response::with((status::NoContent,
                            Header(headers::Server(USER_AGENT.to_string())),
                            Header(headers::Allow(vec![method::Options, method::Get, method::Put, method::Delete, method::Head, method::Trace])))))
@@ -104,11 +115,11 @@ impl HttpHandler {
     }
 
     fn handle_invalid_url(&self, req: &mut Request, cause: &str) -> IronResult<Response> {
-        println!("{} requested to {} {} with invalid URL -- {}",
-                 req.remote_addr,
-                 req.method,
-                 req.url,
-                 cause.replace("<p>", "").replace("</p>", ""));
+        log!("{} requested to {} {} with invalid URL -- {}",
+             req.remote_addr,
+             req.method,
+             req.url,
+             cause.replace("<p>", "").replace("</p>", ""));
 
 
         self.handle_generated_response_encoding(req,
@@ -117,7 +128,7 @@ impl HttpHandler {
     }
 
     fn handle_nonexistant(&self, req: &mut Request, req_p: PathBuf) -> IronResult<Response> {
-        println!("{} requested to {} nonexistant entity {}", req.remote_addr, req.method, req_p.display());
+        log!("{} requested to {} nonexistant entity {}", req.remote_addr, req.method, req_p.display());
         let url_p = url_path(&req.url);
         self.handle_generated_response_encoding(req,
                                                 status::NotFound,
@@ -131,7 +142,7 @@ impl HttpHandler {
         } else {
             "text/plain".parse().unwrap()
         });
-        println!("{} was served file {} as {}", req.remote_addr, req_p.display(), mime_type);
+        log!("{} was served file {} as {}", req.remote_addr, req_p.display(), mime_type);
 
         let flen = req_p.metadata().unwrap().len();
         if self.encoded_temp_dir.is_some() && flen > MIN_ENCODING_SIZE && flen < MAX_ENCODING_SIZE {
@@ -152,10 +163,10 @@ impl HttpHandler {
 
             {
                 if let Some(resp_p) = self.cache_fs.read().unwrap().get(&cache_key) {
-                    println!("{} encoded as {} for {:.1}% ratio (cached)",
-                             iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
-                             encoding,
-                             ((req_p.metadata().unwrap().len() as f64) / (resp_p.metadata().unwrap().len() as f64)) * 100f64);
+                    log!("{} encoded as {} for {:.1}% ratio (cached)",
+                         iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
+                         encoding,
+                         ((req_p.metadata().unwrap().len() as f64) / (resp_p.metadata().unwrap().len() as f64)) * 100f64);
 
                     return Ok(Response::with((status::Ok,
                                               Header(headers::Server(USER_AGENT.to_string())),
@@ -174,10 +185,10 @@ impl HttpHandler {
             };
 
             if encode_file(&req_p, &resp_p, &encoding) {
-                println!("{} encoded as {} for {:.1}% ratio",
-                         iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
-                         encoding,
-                         ((req_p.metadata().unwrap().len() as f64) / (resp_p.metadata().unwrap().len() as f64)) * 100f64);
+                log!("{} encoded as {} for {:.1}% ratio",
+                     iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
+                     encoding,
+                     ((req_p.metadata().unwrap().len() as f64) / (resp_p.metadata().unwrap().len() as f64)) * 100f64);
 
                 let mut cache = self.cache_fs.write().unwrap();
                 cache.insert(cache_key, resp_p.clone());
@@ -188,9 +199,9 @@ impl HttpHandler {
                                           resp_p.as_path(),
                                           mt)));
             } else {
-                println!("{} failed to encode as {}, sending identity",
-                         iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
-                         encoding);
+                log!("{} failed to encode as {}, sending identity",
+                     iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
+                     encoding);
             }
         }
 
@@ -211,9 +222,9 @@ impl HttpHandler {
                 }) {
                 if req.url.path().pop() == Some("") {
                     let r = self.handle_get_file(req, idx);
-                    println!("{} found index file for directory {}",
-                             iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
-                             req_p.display());
+                    log!("{} found index file for directory {}",
+                         iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
+                         req_p.display());
                     return r;
                 } else {
                     return self.handle_get_dir_index_no_slash(req, e);
@@ -226,7 +237,7 @@ impl HttpHandler {
 
     fn handle_get_dir_index_no_slash(&self, req: &mut Request, idx_ext: &str) -> IronResult<Response> {
         let new_url = req.url.to_string() + "/";
-        println!("Redirecting {} to {} - found index file index.{}", req.remote_addr, new_url, idx_ext);
+        log!("Redirecting {} to {} - found index file index.{}", req.remote_addr, new_url, idx_ext);
 
         // We redirect here because if we don't and serve the index right away funky shit happens.
         // Example:
@@ -240,7 +251,7 @@ impl HttpHandler {
     fn handle_get_dir_listing(&self, req: &mut Request, req_p: PathBuf) -> IronResult<Response> {
         let relpath = (url_path(&req.url) + "/").replace("//", "/");
         let is_root = &req.url.path() == &[""];
-        println!("{} was served directory listing for {}", req.remote_addr, req_p.display());
+        log!("{} was served directory listing for {}", req.remote_addr, req_p.display());
         self.handle_generated_response_encoding(req,
                                                 status::Ok,
                                                 html_response(DIRECTORY_LISTING_HTML,
@@ -256,7 +267,7 @@ impl HttpHandler {
                                                                     format!("<tr><td><a href=\"../\"><img id=\"parent_dir\" \
                                                                              src=\"{{back_arrow_icon}}\"></img></a></td> <td><a href=\"../\">Parent \
                                                                              directory</a></td> <td>{}</td> <td></td></tr>",
-                                                                            strftime("%F %T", &file_time_modified(req_p.parent().unwrap())).unwrap())
+                                                                            file_time_modified(req_p.parent().unwrap()).strftime("%F %T").unwrap())
                                                                 },
                                                                 &req_p.read_dir()
                                                                     .unwrap()
@@ -348,12 +359,12 @@ impl HttpHandler {
             })
             .to_string();
 
-        println!("{} tried to {} on {} ({}) but only {} are allowed",
-                 req.remote_addr,
-                 req.method,
-                 url_path(&req.url),
-                 tpe,
-                 allowed_s);
+        log!("{} tried to {} on {} ({}) but only {} are allowed",
+             req.remote_addr,
+             req.method,
+             url_path(&req.url),
+             tpe,
+             allowed_s);
 
         let resp_text =
             html_response(ERROR_HTML,
@@ -366,7 +377,7 @@ impl HttpHandler {
     }
 
     fn handle_put_partial_content(&self, req: &mut Request) -> IronResult<Response> {
-        println!("{} tried to PUT partial content to {}", req.remote_addr, url_path(&req.url));
+        log!("{} tried to PUT partial content to {}", req.remote_addr, url_path(&req.url));
         self.handle_generated_response_encoding(req,
                                                 status::BadRequest,
                                                 html_response(ERROR_HTML,
@@ -378,11 +389,11 @@ impl HttpHandler {
 
     fn handle_put_file(&self, req: &mut Request, req_p: PathBuf) -> IronResult<Response> {
         let existant = req_p.exists();
-        println!("{} {} {}, size: {}B",
-                 req.remote_addr,
-                 if existant { "replaced" } else { "created" },
-                 req_p.display(),
-                 *req.headers.get::<headers::ContentLength>().unwrap());
+        log!("{} {} {}, size: {}B",
+             req.remote_addr,
+             if existant { "replaced" } else { "created" },
+             req_p.display(),
+             *req.headers.get::<headers::ContentLength>().unwrap());
 
         let &(_, ref temp_dir) = self.writes_temp_dir.as_ref().unwrap();
         let temp_file_p = temp_dir.join(req_p.file_name().unwrap());
@@ -416,10 +427,10 @@ impl HttpHandler {
     }
 
     fn handle_delete_path(&self, req: &mut Request, req_p: PathBuf) -> IronResult<Response> {
-        println!("{} deleted {} {}",
-                 req.remote_addr,
-                 if req_p.is_file() { "file" } else { "directory" },
-                 req_p.display());
+        log!("{} deleted {} {}",
+             req.remote_addr,
+             if req_p.is_file() { "file" } else { "directory" },
+             req_p.display());
 
         if req_p.is_file() {
             fs::remove_file(req_p).unwrap();
@@ -431,7 +442,7 @@ impl HttpHandler {
     }
 
     fn handle_trace(&self, req: &mut Request) -> IronResult<Response> {
-        println!("{} requested TRACE", req.remote_addr);
+        log!("{} requested TRACE", req.remote_addr);
 
         let mut hdr = req.headers.clone();
         hdr.set(headers::ContentType("message/http".parse().unwrap()));
@@ -445,7 +456,7 @@ impl HttpHandler {
     }
 
     fn handle_forbidden_method(&self, req: &mut Request, switch: &str, desc: &str) -> IronResult<Response> {
-        println!("{} used disabled request method {} grouped under {}", req.remote_addr, req.method, desc);
+        log!("{} used disabled request method {} grouped under {}", req.remote_addr, req.method, desc);
         self.handle_generated_response_encoding(req,
                                                 status::Forbidden,
                                                 html_response(ERROR_HTML,
@@ -458,7 +469,7 @@ impl HttpHandler {
     }
 
     fn handle_bad_method(&self, req: &mut Request) -> IronResult<Response> {
-        println!("{} used invalid request method {}", req.remote_addr, req.method);
+        log!("{} used invalid request method {}", req.remote_addr, req.method);
         let last_p = format!("<p>Unsupported request method: {}.<br />\nSupported methods: OPTIONS, GET, PUT, DELETE, HEAD and TRACE.</p>",
                              req.method);
         self.handle_generated_response_encoding(req,
@@ -473,10 +484,10 @@ impl HttpHandler {
 
             {
                 if let Some(enc_resp) = self.cache_gen.read().unwrap().get(&cache_key) {
-                    println!("{} encoded as {} for {:.1}% ratio (cached)",
-                             iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
-                             encoding,
-                             ((resp.len() as f64) / (enc_resp.len() as f64)) * 100f64);
+                    log!("{} encoded as {} for {:.1}% ratio (cached)",
+                         iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
+                         encoding,
+                         ((resp.len() as f64) / (enc_resp.len() as f64)) * 100f64);
 
                     return Ok(Response::with((st,
                                               Header(headers::Server(USER_AGENT.to_string())),
@@ -487,10 +498,10 @@ impl HttpHandler {
             }
 
             if let Some(enc_resp) = encode_str(&resp, &encoding) {
-                println!("{} encoded as {} for {:.1}% ratio",
-                         iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
-                         encoding,
-                         ((resp.len() as f64) / (enc_resp.len() as f64)) * 100f64);
+                log!("{} encoded as {} for {:.1}% ratio",
+                     iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
+                     encoding,
+                     ((resp.len() as f64) / (enc_resp.len() as f64)) * 100f64);
 
                 let mut cache = self.cache_gen.write().unwrap();
                 cache.insert(cache_key.clone(), enc_resp);
@@ -501,9 +512,9 @@ impl HttpHandler {
                                           "text/html;charset=utf-8".parse::<mime::Mime>().unwrap(),
                                           &cache[&cache_key][..])));
             } else {
-                println!("{} failed to encode as {}, sending identity",
-                         iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
-                         encoding);
+                log!("{} failed to encode as {}, sending identity",
+                     iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
+                     encoding);
             }
         }
 
@@ -530,7 +541,7 @@ impl HttpHandler {
     fn create_temp_dir(&self, td: &Option<(String, PathBuf)>) {
         let &(ref temp_name, ref temp_dir) = td.as_ref().unwrap();
         if !temp_dir.exists() && fs::create_dir_all(&temp_dir).is_ok() {
-            println!("Created temp dir {}", temp_name);
+            log!("Created temp dir {}", temp_name);
         }
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -11,6 +11,7 @@ use iron::modifiers::Header;
 use std::collections::HashMap;
 use self::super::{Options, Error};
 use mime_guess::guess_mime_type_opt;
+use trivial_colours::{Reset as CReset, Colour as C};
 use iron::{headers, status, method, mime, IronResult, Listening, Response, TypeMap, Request, Handler, Iron};
 use self::super::util::{url_path, file_hash, is_symlink, encode_str, encode_file, hash_string, html_response, file_binary, percent_decode, response_encoding,
                         detect_file_as_dir, encoding_extension, file_time_modified, human_readable_size, USER_AGENT, ERROR_HTML, INDEX_EXTENSIONS,
@@ -19,11 +20,11 @@ use self::super::util::{url_path, file_hash, is_symlink, encode_str, encode_file
 
 macro_rules! log {
     ($fmt:expr) => {
-        print!("[{}] ", now().strftime("%F %T").unwrap());
+        print!("{}[{}]{} ", C::Cyan, now().strftime("%F %T").unwrap(), CReset);
         println!($fmt);
     };
     ($fmt:expr, $($arg:tt)*) => {
-        print!("[{}] ", now().strftime("%F %T").unwrap());
+        print!("{}[{}]{} ", C::Cyan, now().strftime("%F %T").unwrap(), CReset);
         println!($fmt, $($arg)*);
     };
 }
@@ -94,7 +95,7 @@ impl Handler for HttpHandler {
 
 impl HttpHandler {
     fn handle_options(&self, req: &mut Request) -> IronResult<Response> {
-        log!("{} asked for options", req.remote_addr);
+        log!("{}{}{} asked for {}OPTIONS{}", C::Green, req.remote_addr, CReset, C::Red, CReset);
         Ok(Response::with((status::NoContent,
                            Header(headers::Server(USER_AGENT.to_string())),
                            Header(headers::Allow(vec![method::Options, method::Get, method::Put, method::Delete, method::Head, method::Trace])))))
@@ -115,10 +116,16 @@ impl HttpHandler {
     }
 
     fn handle_invalid_url(&self, req: &mut Request, cause: &str) -> IronResult<Response> {
-        log!("{} requested to {} {} with invalid URL -- {}",
+        log!("{}{}{} requested to {}{}{} {}{}{} with invalid URL -- {}",
+             C::Green,
              req.remote_addr,
+             CReset,
+             C::Red,
              req.method,
+             CReset,
+             C::Yellow,
              req.url,
+             CReset,
              cause.replace("<p>", "").replace("</p>", ""));
 
 
@@ -128,7 +135,16 @@ impl HttpHandler {
     }
 
     fn handle_nonexistant(&self, req: &mut Request, req_p: PathBuf) -> IronResult<Response> {
-        log!("{} requested to {} nonexistant entity {}", req.remote_addr, req.method, req_p.display());
+        log!("{}{}{} requested to {}{}{} nonexistant entity {}{}{}",
+             C::Green,
+             req.remote_addr,
+             CReset,
+             C::Red,
+             req.method,
+             CReset,
+             C::Magenta,
+             req_p.display(),
+             CReset);
         let url_p = url_path(&req.url);
         self.handle_generated_response_encoding(req,
                                                 status::NotFound,
@@ -142,7 +158,16 @@ impl HttpHandler {
         } else {
             "text/plain".parse().unwrap()
         });
-        log!("{} was served file {} as {}", req.remote_addr, req_p.display(), mime_type);
+        log!("{}{}{} was served file {}{}{} as {}{}{}",
+             C::Green,
+             req.remote_addr,
+             CReset,
+             C::Magenta,
+             req_p.display(),
+             CReset,
+             C::Blue,
+             mime_type,
+             CReset);
 
         let flen = req_p.metadata().unwrap().len();
         if self.encoded_temp_dir.is_some() && flen > MIN_ENCODING_SIZE && flen < MAX_ENCODING_SIZE {
@@ -222,9 +247,11 @@ impl HttpHandler {
                 }) {
                 if req.url.path().pop() == Some("") {
                     let r = self.handle_get_file(req, idx);
-                    log!("{} found index file for directory {}",
+                    log!("{} found index file for directory {}{}{}",
                          iter::repeat(' ').take(req.remote_addr.to_string().len()).collect::<String>(),
-                         req_p.display());
+                         C::Magenta
+                         req_p.display(),
+                         CReset);
                     return r;
                 } else {
                     return self.handle_get_dir_index_no_slash(req, e);
@@ -237,7 +264,16 @@ impl HttpHandler {
 
     fn handle_get_dir_index_no_slash(&self, req: &mut Request, idx_ext: &str) -> IronResult<Response> {
         let new_url = req.url.to_string() + "/";
-        log!("Redirecting {} to {} - found index file index.{}", req.remote_addr, new_url, idx_ext);
+        log!("Redirecting {}{}{} to {}{}{} - found index file {}index.{}{}",
+             C::Green,
+             req.remote_addr,
+             CReset,
+             C::Green,
+             new_url,
+             CReset,
+             C::Magenta,
+             idx_ext,
+             CReset);
 
         // We redirect here because if we don't and serve the index right away funky shit happens.
         // Example:
@@ -251,7 +287,13 @@ impl HttpHandler {
     fn handle_get_dir_listing(&self, req: &mut Request, req_p: PathBuf) -> IronResult<Response> {
         let relpath = (url_path(&req.url) + "/").replace("//", "/");
         let is_root = &req.url.path() == &[""];
-        log!("{} was served directory listing for {}", req.remote_addr, req_p.display());
+        log!("{}{}{} was served directory listing for {}{}{}",
+             C::Green,
+             req.remote_addr,
+             CReset,
+             C::Magenta,
+             req_p.display(),
+             CReset);
         self.handle_generated_response_encoding(req,
                                                 status::Ok,
                                                 html_response(DIRECTORY_LISTING_HTML,
@@ -359,12 +401,22 @@ impl HttpHandler {
             })
             .to_string();
 
-        log!("{} tried to {} on {} ({}) but only {} are allowed",
+        log!("{}{}{} tried to {}{}{} on {}{}{} ({}{}{}) but only {}{}{} are allowed",
+             C::Green,
              req.remote_addr,
+             CReset,
+             C::Red,
              req.method,
+             CReset,
+             C::Magenta,
              url_path(&req.url),
+             CReset,
+             C::Blue,
              tpe,
-             allowed_s);
+             CReset,
+             C::Red,
+             allowed_s,
+             CReset);
 
         let resp_text =
             html_response(ERROR_HTML,
@@ -377,7 +429,15 @@ impl HttpHandler {
     }
 
     fn handle_put_partial_content(&self, req: &mut Request) -> IronResult<Response> {
-        log!("{} tried to PUT partial content to {}", req.remote_addr, url_path(&req.url));
+        log!("{}{}{} tried to {}PUT{} partial content to {}{}{}",
+             C::Green,
+             req.remote_addr,
+             CReset,
+             C::Red,
+             CReset,
+             C::Yellow,
+             url_path(&req.url),
+             CReset);
         self.handle_generated_response_encoding(req,
                                                 status::BadRequest,
                                                 html_response(ERROR_HTML,
@@ -389,10 +449,14 @@ impl HttpHandler {
 
     fn handle_put_file(&self, req: &mut Request, req_p: PathBuf) -> IronResult<Response> {
         let existant = req_p.exists();
-        log!("{} {} {}, size: {}B",
+        log!("{}{}{} {} {}{}{}, size: {}B",
+             C::Green,
              req.remote_addr,
+             CReset,
              if existant { "replaced" } else { "created" },
+             C::Magenta,
              req_p.display(),
+             CReset,
              *req.headers.get::<headers::ContentLength>().unwrap());
 
         let &(_, ref temp_dir) = self.writes_temp_dir.as_ref().unwrap();
@@ -427,10 +491,15 @@ impl HttpHandler {
     }
 
     fn handle_delete_path(&self, req: &mut Request, req_p: PathBuf) -> IronResult<Response> {
-        log!("{} deleted {} {}",
+        log!("{}{}{} deleted {}{} {}{}{}",
+             C::Green,
              req.remote_addr,
+             CReset,
+             C::Blue,
              if req_p.is_file() { "file" } else { "directory" },
-             req_p.display());
+             C::Magenta,
+             req_p.display(),
+             CReset);
 
         if req_p.is_file() {
             fs::remove_file(req_p).unwrap();
@@ -442,7 +511,7 @@ impl HttpHandler {
     }
 
     fn handle_trace(&self, req: &mut Request) -> IronResult<Response> {
-        log!("{} requested TRACE", req.remote_addr);
+        log!("{}{}{} requested {}TRACE{} for {}{}{}", C::Green, req.remote_addr, CReset, C::Red, CReset, C::Magenta, url_path(&req.url), CReset);
 
         let mut hdr = req.headers.clone();
         hdr.set(headers::ContentType("message/http".parse().unwrap()));
@@ -456,7 +525,14 @@ impl HttpHandler {
     }
 
     fn handle_forbidden_method(&self, req: &mut Request, switch: &str, desc: &str) -> IronResult<Response> {
-        log!("{} used disabled request method {} grouped under {}", req.remote_addr, req.method, desc);
+        log!("{}{}{} used disabled request method {}{}{} grouped under {}",
+             C::Green,
+             req.remote_addr,
+             CReset,
+             C::Red,
+             req.method,
+             CReset,
+             desc);
         self.handle_generated_response_encoding(req,
                                                 status::Forbidden,
                                                 html_response(ERROR_HTML,
@@ -469,7 +545,13 @@ impl HttpHandler {
     }
 
     fn handle_bad_method(&self, req: &mut Request) -> IronResult<Response> {
-        log!("{} used invalid request method {}", req.remote_addr, req.method);
+        log!("{}{}{} used invalid request method {}{}{}",
+             C::Green,
+             req.remote_addr,
+             CReset,
+             C::Red,
+             req.method,
+             CReset);
         let last_p = format!("<p>Unsupported request method: {}.<br />\nSupported methods: OPTIONS, GET, PUT, DELETE, HEAD and TRACE.</p>",
                              req.method);
         self.handle_generated_response_encoding(req,
@@ -541,7 +623,7 @@ impl HttpHandler {
     fn create_temp_dir(&self, td: &Option<(String, PathBuf)>) {
         let &(ref temp_name, ref temp_dir) = td.as_ref().unwrap();
         if !temp_dir.exists() && fs::create_dir_all(&temp_dir).is_ok() {
-            log!("Created temp dir {}", temp_name);
+            log!("Created temp dir {}{}{}", C::Magenta, temp_name, CReset);
         }
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -309,7 +309,7 @@ impl HttpHandler {
                         fname,
                         fname,
                         if is_file { "" } else { "/" },
-                        strftime("%F %T", &file_time_modified(&path)).unwrap(),
+                        file_time_modified(&path).strftime("%F %T").unwrap(),
                         if is_file {
                             len.to_string()
                         } else {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -307,7 +307,7 @@ impl HttpHandler {
                                                                     String::new()
                                                                 } else {
                                                                     format!("<tr><td><a href=\"../\"><img id=\"parent_dir\" \
-                                                                             src=\"{{back_arrow_icon}}\"></img></a></td> <td><a href=\"../\">Parent \
+                                                                             src=\"{{back_arrow_icon}}\" /></a></td> <td><a href=\"../\">Parent \
                                                                              directory</a></td> <td>{}</td> <td></td></tr>",
                                                                             file_time_modified(req_p.parent().unwrap()).strftime("%F %T").unwrap())
                                                                 },
@@ -339,7 +339,7 @@ impl HttpHandler {
                     ""
                 };
 
-                format!("{}<tr><td><a href=\"{}{}\"><img id=\"{}\" src=\"{{{}{}_icon}}\"></img></a></td> <td><a href=\"{}{}\">{}{}</a></td> <td>{}</td> \
+                format!("{}<tr><td><a href=\"{}{}\"><img id=\"{}\" src=\"{{{}{}_icon}}\" /></a></td> <td><a href=\"{}{}\">{}{}</a></td> <td>{}</td> \
                          <td><abbr title=\"{} B\">{}</abbr></td></tr>\n",
                         cur,
                         url,

--- a/src/options.rs
+++ b/src/options.rs
@@ -25,7 +25,7 @@ pub struct Options {
     pub hosted_directory: (String, PathBuf),
     /// The port to host on. Default: first free port from 8000 up
     pub port: Option<u16>,
-    /// Whether to allow symlinks to be requested. Default: false
+    /// Whether to allow symlinks to be requested. Default: true
     pub follow_symlinks: bool,
     /// The temp directory to write to before copying to hosted directory. Default: `None`
     pub temp_directory: Option<(String, PathBuf)>,
@@ -47,7 +47,7 @@ impl Options {
             .arg(Arg::from_usage("-p --port [port] 'Port to use. Default: first free port from 8000 up'").validator(Options::u16_validator))
             .arg(Arg::from_usage("-t --temp-dir [temp] 'Temporary directory. Default: $TEMP'")
                 .validator(|s| Options::filesystem_dir_validator(s, "Temporary directory")))
-            .arg(Arg::from_usage("-s --follow-symlinks 'Follow symlinks. Default: false'"))
+            .arg(Arg::from_usage("-s --no-follow-symlinks 'Don't follow symlinks. Default: false'"))
             .arg(Arg::from_usage("-w --allow-write 'Allow for write operations. Default: false'"))
             .arg(Arg::from_usage("-i --no-indices 'Always generate dir listings even if index files are available. Default: false'"))
             .arg(Arg::from_usage("-e --no-encode 'Do not encode filesystem files. Default: false'"))
@@ -60,7 +60,7 @@ impl Options {
         Options {
             hosted_directory: (dir.to_string(), dir_pb.clone()),
             port: matches.value_of("port").map(u16::from_str).map(Result::unwrap),
-            follow_symlinks: matches.is_present("follow-symlinks"),
+            follow_symlinks: !matches.is_present("no-follow-symlinks"),
             temp_directory: if w || e {
                 let (temp_s, temp_pb) = if let Some(tmpdir) = matches.value_of("temp-dir") {
                     (tmpdir.to_string(), fs::canonicalize(tmpdir).unwrap())

--- a/src/options.rs
+++ b/src/options.rs
@@ -67,8 +67,8 @@ impl Options {
                 } else {
                     ("$TEMP".to_string(), temp_dir())
                 };
-                let suffix = format!("http-{}",
-                                     dir_pb.into_os_string().to_str().unwrap().replace(r"\\?\", "").replace(':', "").replace('\\', "/").replace('/', "-"));
+                let suffix = dir_pb.into_os_string().to_str().unwrap().replace(r"\\?\", "").replace(':', "").replace('\\', "/").replace('/', "-");
+                let suffix = format!("http{}{}", if suffix.starts_with('-') { "" } else { "-" }, suffix);
 
                 Some((format!("{}{}{}",
                               temp_s,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -28,7 +28,7 @@ pub static DIRECTORY_LISTING_HTML: &'static str = include_str!("../../assets/dir
 lazy_static! {
     /// Collection of data to be injected into generated responses.
     pub static ref ASSETS: HashMap<&'static str, Cow<'static, str>> = {
-        let mut ass = HashMap::with_capacity(1);
+        let mut ass = HashMap::with_capacity(8);
         ass.insert("favicon",
             Cow::Owned(format!("data:{};base64,{}", get_mime_type_str("ico").unwrap(), base64::encode(include_bytes!("../../assets/favicon.ico")))));
         ass.insert("dir_icon",

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -203,11 +203,15 @@ pub fn is_symlink<P: AsRef<Path>>(p: P) -> bool {
 ///
 /// Stolen, adapted and inlined from [fielsize.js](http://filesizejs.com).
 pub fn human_readable_size(s: u64) -> String {
+    lazy_static! {
+        static ref LN_KIB: f64 = 1024f64.log(f64::consts::E);
+    }
+
     if s == 0 {
         "0 B".to_string()
     } else {
         let num = s as f64;
-        let exp = cmp::min(cmp::max((num.log(f64::consts::E) / 1024f64.log(f64::consts::E)) as i32, 0), 8);
+        let exp = cmp::min(cmp::max((num.log(f64::consts::E) / *LN_KIB) as i32, 0), 8);
 
         let val = num / 2f64.powi(exp * 10);
 


### PR DESCRIPTION
Logging and good symlinks are done now and here's the rundown:

  * [x] symlinks are followed by default, `-s` option now *disables* symlink following
  * [x] all log lines are prefixed by timestamp [1]
  * [x] log is colourised with a strictly defined colourset [2]

[1] If there is more metadata to add this shouldn't close 33.
[2] Only on non-Windows. Windows is obnoxious when it comes to this (and way too slow).

Closes #33

<sub>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</sub>