### PR TITLE
Properly handle Unix devices. Also build httplz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ version = "0.2"
 [build-dependencies]
 embed-resource = "1.1"
 
+[target.'cfg(not(target_os = "windows"))'.build-dependencies.gcc]
+version = "0.3"
+
 
 [[bin]]
 name = "http"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,9 @@ name = "http"
 path = "src/main.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "httplz"
+path = "src/main.rs"
+test = false
+doc = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ default-features = false
 version = "0.5"
 features = ["hyper-native-tls"]
 
+[target.'cfg(not(target_os = "windows"))'.dependencies.libc]
+version = "0.2"
+
 [build-dependencies]
 embed-resource = "1.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "1.3.1"
+version = "1.3.2"
 # Remember to also update in http.md
 authors = ["thecoshman <thecoshman@gmail.com>",
            "nabijaczleweli <nabijaczleweli@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# http [![Travis build status](https://travis-ci.org/thecoshman/http.svg)](https://travis-ci.org/thecoshman/http) [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/7knk9lnptn1njro5?svg=true)](https://ci.appveyor.com/project/thecoshman/http) [![Licence](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE) [![Crates.io version](http://meritbadge.herokuapp.com/https)](https://crates.io/crates/https)
+# http [![Travis build status](https://travis-ci.org/thecoshman/http.svg)](https://travis-ci.org/thecoshman/http) [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/7knk9lnptn1njro5?svg=true)](https://ci.appveyor.com/project/thecoshman/http) [![Licence](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE) [![Crates.io version](https://meritbadge.herokuapp.com/https)](https://crates.io/crates/https)
 Host These Things Please - a basic HTTP server for hosting a folder fast and simply
 
 ## Selected features

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.3.1-{build}
+version: 1.3.2-{build}
 
 skip_tags: false
 
@@ -22,21 +22,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v1.3.1.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.3.1.exe
-  - makensis -DHTTP_VERSION=v1.3.1 "/X!include \"EnvVarUpdate.nsh\"" install.nsi
+  - cp target\release\http.exe http-v1.3.2.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.3.2.exe
+  - makensis -DHTTP_VERSION=v1.3.2 "/X!include \"EnvVarUpdate.nsh\"" install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v1.3.1.exe
-  - path: http v1.3.1 installer.exe
+  - path: http-v1.3.2.exe
+  - path: http v1.3.2 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v1.3.1.*\.exe/
+  artifact: /http.*v1.3.2.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,56 @@
 extern crate embed_resource;
+#[cfg(not(target_os = "windows"))]
+extern crate gcc;
+
+#[cfg(not(target_os = "windows"))]
+use std::env;
+#[cfg(not(target_os = "windows"))]
+use std::io::Write;
+#[cfg(not(target_os = "windows"))]
+use std::path::Path;
+#[cfg(not(target_os = "windows"))]
+use std::fs::{self, File};
+
+
+/// The last line of this, after running it through a preprocessor, will expand to the value of `BLKGETSIZE`
+static IOCTL_CHECK_SOURCE: &str = r#"
+#include <linux/fs.h>
+
+BLKGETSIZE
+"#;
+
+/// Replace `{}` with the `BLKGETSIZE` expression from `IOCTL_CHECK_SOURCE`
+static IOCTL_INCLUDE_SKELETON: &str = r#"
+/// Return `device size / 512` (`long *` arg)
+static BLKGETSIZE: c_ulong = {};
+"#;
 
 
 fn main() {
+    embed_resources();
+    get_ioctl_data();
+}
+
+fn embed_resources() {
     embed_resource::compile("http-manifest.rc");
+}
+
+#[cfg(target_os = "windows")]
+fn get_ioctl_data() {
+
+}
+
+#[cfg(not(target_os = "windows"))]
+fn get_ioctl_data() {
+    let ioctl_dir = Path::new(&env::var("OUT_DIR").unwrap()).join("ioctl-data");
+    fs::create_dir_all(&ioctl_dir).unwrap();
+
+    let ioctl_source = ioctl_dir.join("ioctl.c");
+    File::create(&ioctl_source).unwrap().write_all(IOCTL_CHECK_SOURCE.as_bytes()).unwrap();
+
+    let ioctl_preprocessed = String::from_utf8(gcc::Build::new().file(ioctl_source).expand()).unwrap();
+    let blkgetsize_expr = ioctl_preprocessed.lines().next_back().unwrap().replace("U", " as c_ulong");
+
+    let ioctl_include = ioctl_dir.join("ioctl.rs");
+    File::create(&ioctl_include).unwrap().write_all(IOCTL_INCLUDE_SKELETON.replace("{}", &blkgetsize_expr).as_bytes()).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ extern crate serde;
 #[macro_use]
 extern crate clap;
 extern crate iron;
+#[cfg(not(target_os = "windows"))]
+extern crate libc;
 extern crate time;
 extern crate url;
 extern crate md6;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -444,8 +444,8 @@ impl HttpHandler {
                            (Header(headers::Server(USER_AGENT.to_string())),
                             Header(headers::LastModified(headers::HttpDate(file_time_modified(&req_p)))),
                             Header(headers::AcceptRanges(vec![headers::RangeUnit::Bytes]))),
-                           req_p,
-                           Header(headers::ContentLength(file_length(&metadata, &req_p))),
+                           req_p.as_path(),
+                           Header(headers::ContentLength(file_length(&req_p.metadata().expect("Failed to get requested file metadata"), &req_p))),
                            mt)))
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -19,6 +19,7 @@ use std::io::{BufReader, BufRead};
 use base64::display::Base64Display;
 use mime_guess::{guess_mime_type_opt, get_mime_type_str};
 
+pub use self::os::*;
 pub use self::content_encoding::*;
 
 
@@ -117,7 +118,9 @@ pub fn uppercase_first(s: &str) -> String {
 /// ```
 pub fn file_binary<P: AsRef<Path>>(path: P) -> bool {
     let path = path.as_ref();
-    path.metadata().map(|m| os::is_device(&m.file_type()) || File::open(path).and_then(|f| BufReader::new(f).read_line(&mut String::new())).is_err()).unwrap_or(true)
+    path.metadata()
+        .map(|m| is_device(&m.file_type()) || File::open(path).and_then(|f| BufReader::new(f).read_line(&mut String::new())).is_err())
+        .unwrap_or(true)
 }
 
 /// Fill out an HTML template.
@@ -213,7 +216,7 @@ pub fn is_symlink<P: AsRef<Path>>(p: P) -> bool {
 
 /// Check if a path refers to a file in a way that includes Unix devices and Windows symlinks.
 pub fn is_actually_file(tp: &FileType) -> bool {
-    tp.is_file() || os::is_device(tp)
+    tp.is_file() || is_device(tp)
 }
 
 /// Construct string representing a human-readable size.

--- a/src/util/os/mod.rs
+++ b/src/util/os/mod.rs
@@ -4,6 +4,6 @@ mod windows;
 mod non_windows;
 
 #[cfg(target_os = "windows")]
-pub use self::windows::is_device;
+pub use self::windows::{file_length, is_device};
 #[cfg(not(target_os = "windows"))]
-pub use self::non_windows::is_device;
+pub use self::non_windows::{file_length, is_device};

--- a/src/util/os/mod.rs
+++ b/src/util/os/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(not(target_os = "windows"))]
+mod non_windows;
+
+#[cfg(target_os = "windows")]
+pub use self::windows::is_device;
+#[cfg(not(target_os = "windows"))]
+pub use self::non_windows::is_device;

--- a/src/util/os/non_windows.rs
+++ b/src/util/os/non_windows.rs
@@ -1,0 +1,8 @@
+use std::fs::FileType;
+use std::os::unix::fs::FileTypeExt;
+
+
+/// OS-specific check for fileness
+pub fn is_device(tp: &FileType) -> bool {
+    tp.is_block_device() || tp.is_char_device() || tp.is_fifo() || tp.is_socket()
+}

--- a/src/util/os/non_windows.rs
+++ b/src/util/os/non_windows.rs
@@ -1,8 +1,40 @@
-use std::fs::FileType;
+use libc::{O_RDONLY, c_ulong, close, ioctl, open};
 use std::os::unix::fs::FileTypeExt;
+use std::os::unix::ffi::OsStrExt;
+use std::fs::{FileType, Metadata};
+use std::ffi::CString;
+use std::path::Path;
+
+
+/// Return `device size / 512` (`long *` arg)
+///
+/// Extracted from my armv6l machine
+///
+/// Would be probably a good idea to get this at build time from a build script
+const BLKGETSIZE: c_ulong = (0x12 << 8) | 96;
 
 
 /// OS-specific check for fileness
 pub fn is_device(tp: &FileType) -> bool {
     tp.is_block_device() || tp.is_char_device() || tp.is_fifo() || tp.is_socket()
+}
+
+/// Check file length responsibly
+pub fn file_length<P: AsRef<Path>>(meta: &Metadata, path: &P) -> u64 {
+    if is_device(&meta.file_type()) {
+        let mut block_count: c_ulong = 0;
+
+        let path_c = CString::new(path.as_ref().as_os_str().as_bytes()).unwrap();
+        let dev_file = unsafe { open(path_c.as_ptr(), O_RDONLY) };
+        if dev_file >= 0 {
+            let ok = unsafe { ioctl(dev_file, BLKGETSIZE, &mut block_count as *mut c_ulong) } == 0;
+            unsafe { close(dev_file) };
+
+            if ok {
+                return block_count as u64 * 512;
+            }
+        }
+    }
+
+    meta.len()
 }

--- a/src/util/os/non_windows.rs
+++ b/src/util/os/non_windows.rs
@@ -6,12 +6,7 @@ use std::ffi::CString;
 use std::path::Path;
 
 
-/// Return `device size / 512` (`long *` arg)
-///
-/// Extracted from my armv6l machine
-///
-/// Would be probably a good idea to get this at build time from a build script
-const BLKGETSIZE: c_ulong = (0x12 << 8) | 96;
+include!(concat!(env!("OUT_DIR"), "/ioctl-data/ioctl.rs"));
 
 
 /// OS-specific check for fileness

--- a/src/util/os/windows.rs
+++ b/src/util/os/windows.rs
@@ -1,0 +1,7 @@
+use std::fs::FileType;
+
+
+/// OS-specific check for fileness
+pub fn is_device(_: &FileType) -> bool {
+    false
+}

--- a/src/util/os/windows.rs
+++ b/src/util/os/windows.rs
@@ -1,7 +1,13 @@
-use std::fs::FileType;
+use std::fs::{FileType, Metadata};
+use std::path::Path;
 
 
 /// OS-specific check for fileness
 pub fn is_device(_: &FileType) -> bool {
     false
+}
+
+/// Check file length responsibly
+pub fn file_length<P: AsRef<Path>>(meta: &Metadata, _: &P) -> u64 {
+    meta.len()
 }


### PR DESCRIPTION
1. Allows you to download, e.g., `/dev/sda2` (closing #66)
2. There are two identical binaries: one called `http` and another called `httplz` (closing #35)

<sub>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</sub>