### PR TITLE
Symlink sandboxing and illegal PUTs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "1.3.3"
+version = "1.4.0"
 # Remember to also update in http.md
 authors = ["thecoshman <thecoshman@gmail.com>",
            "nabijaczleweli <nabijaczleweli@gmail.com>"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.3.3-{build}
+version: 1.4.0-{build}
 
 skip_tags: false
 
@@ -22,21 +22,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v1.3.3.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.3.3.exe
-  - makensis -DHTTP_VERSION=v1.3.3 "/X!include \"EnvVarUpdate.nsh\"" install.nsi
+  - cp target\release\http.exe http-v1.4.0.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.4.0.exe
+  - makensis -DHTTP_VERSION=v1.4.0 "/X!include \"EnvVarUpdate.nsh\"" install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v1.3.3.exe
-  - path: http v1.3.3 installer.exe
+  - path: http-v1.4.0.exe
+  - path: http v1.4.0 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v1.3.3.*\.exe/
+  artifact: /http.*v1.4.0.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:

--- a/http.md
+++ b/http.md
@@ -60,8 +60,16 @@ pass parameters like what port to use.
 
     Don't follow symlinks when requesting file access.
 
-    If a symlink is requested and this is on it will be treated as if it didn't
-    exist.
+    If a symlink is requested and this flag is on it will be treated as if it
+    didn't exist.
+
+  -r --sandbox-symlinks
+
+    Restrict/sandbox where symlinks lead to only the direct descendants
+    of the hosted directory.
+
+    If a file outside the direct descendancy of the hosted reictory requested
+    and this flag is on it will be treated as if it didn't exist.
 
   -w --allow-write
 
@@ -178,6 +186,14 @@ pass parameters like what port to use.
 
     Example output change:
       Hosting "." on port 8000 TLS certificate from "$TEMP/http-P-Rust-http/tls/tls.p12"...
+
+  `http -r`
+
+    As in the first example, but restrict accessible paths
+    to direct descendants of the hosted directory.
+
+    Example output change:
+      127.0.0.1:47916 requested to GET nonexistant entity S:\Rust-target\doc\main.css
 
 ## AUTHOR
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -27,7 +27,11 @@ pub struct Options {
     pub port: Option<u16>,
     /// Whether to allow symlinks to be requested. Default: true
     pub follow_symlinks: bool,
-    /// Whether to disallow going out of the descendants of the hosted directory (via symlinks). Default: false
+    /// Whether to disallow going out of the descendants of the hosted directory (via symlinks)
+    ///
+    /// Can only be true if `follow_symlinks` is true.
+    ///
+    /// Default: false
     pub sandbox_symlinks: bool,
     /// The temp directory to write to before copying to hosted directory and to store encoded FS responses.
     /// Default: `"$TEMP/http-[FULL_PATH_TO_HOSTED_DIR]"`
@@ -58,7 +62,8 @@ impl Options {
             .arg(Arg::from_usage("-t --temp-dir [temp] 'Temporary directory. Default: $TEMP'")
                 .validator(|s| Options::filesystem_dir_validator(s, "Temporary directory")))
             .arg(Arg::from_usage("-s --no-follow-symlinks 'Don't follow symlinks. Default: false'"))
-            .arg(Arg::from_usage("-r --sandbox-symlinks 'Restrict/sandbox where symlinks lead to only the direct descendants of the hosted directory. Default: false'"))
+            .arg(Arg::from_usage("-r --sandbox-symlinks 'Restrict/sandbox where symlinks lead to only the direct descendants of the hosted directory. \
+                                  Default: false'"))
             .arg(Arg::from_usage("-w --allow-write 'Allow for write operations. Default: false'"))
             .arg(Arg::from_usage("-i --no-indices 'Always generate dir listings even if index files are available. Default: false'"))
             .arg(Arg::from_usage("-e --no-encode 'Do not encode filesystem files. Default: false'"))
@@ -69,11 +74,12 @@ impl Options {
 
         let dir = matches.value_of("DIR").unwrap_or(".");
         let dir_pb = fs::canonicalize(dir).unwrap();
+        let follow_symlinks = !matches.is_present("no-follow-symlinks");
         Options {
             hosted_directory: (dir.to_string(), dir_pb.clone()),
             port: matches.value_of("port").map(u16::from_str).map(Result::unwrap),
-            follow_symlinks: !matches.is_present("no-follow-symlinks"),
-            sandbox_symlinks: matches.is_present("sandbox-symlinks"),
+            follow_symlinks: follow_symlinks,
+            sandbox_symlinks: follow_symlinks && matches.is_present("sandbox-symlinks"),
             temp_directory: {
                 let (temp_s, temp_pb) = if let Some(tmpdir) = matches.value_of("temp-dir") {
                     (tmpdir.to_string(), fs::canonicalize(tmpdir).unwrap())

--- a/src/options.rs
+++ b/src/options.rs
@@ -27,6 +27,8 @@ pub struct Options {
     pub port: Option<u16>,
     /// Whether to allow symlinks to be requested. Default: true
     pub follow_symlinks: bool,
+    /// Whether to disallow going out of the descendants of the hosted directory (via symlinks). Default: false
+    pub sandbox_symlinks: bool,
     /// The temp directory to write to before copying to hosted directory and to store encoded FS responses.
     /// Default: `"$TEMP/http-[FULL_PATH_TO_HOSTED_DIR]"`
     pub temp_directory: (String, PathBuf),
@@ -56,6 +58,7 @@ impl Options {
             .arg(Arg::from_usage("-t --temp-dir [temp] 'Temporary directory. Default: $TEMP'")
                 .validator(|s| Options::filesystem_dir_validator(s, "Temporary directory")))
             .arg(Arg::from_usage("-s --no-follow-symlinks 'Don't follow symlinks. Default: false'"))
+            .arg(Arg::from_usage("-r --sandbox-symlinks 'Restrict/sandbox where symlinks lead to only the direct descendants of the hosted directory. Default: false'"))
             .arg(Arg::from_usage("-w --allow-write 'Allow for write operations. Default: false'"))
             .arg(Arg::from_usage("-i --no-indices 'Always generate dir listings even if index files are available. Default: false'"))
             .arg(Arg::from_usage("-e --no-encode 'Do not encode filesystem files. Default: false'"))
@@ -70,6 +73,7 @@ impl Options {
             hosted_directory: (dir.to_string(), dir_pb.clone()),
             port: matches.value_of("port").map(u16::from_str).map(Result::unwrap),
             follow_symlinks: !matches.is_present("no-follow-symlinks"),
+            sandbox_symlinks: matches.is_present("sandbox-symlinks"),
             temp_directory: {
                 let (temp_s, temp_pb) = if let Some(tmpdir) = matches.value_of("temp-dir") {
                     (tmpdir.to_string(), fs::canonicalize(tmpdir).unwrap())

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -242,6 +242,35 @@ pub fn is_descendant_of<Pw: AsRef<Path>, Po: AsRef<Path>>(who: Pw, of_whom: Po) 
     false
 }
 
+/// Check if the specified path is a direct descendant (or an equal) of the specified path, without without requiring it to
+/// exist in the first place.
+pub fn is_nonexistant_descendant_of<Pw: AsRef<Path>, Po: AsRef<Path>>(who: Pw, of_whom: Po) -> bool {
+    let mut who = fs::canonicalize(&who).unwrap_or_else(|_| who.as_ref().to_path_buf());
+    let of_whom = if let Ok(p) = fs::canonicalize(of_whom) {
+        p
+    } else {
+        return false;
+    };
+
+    if who == of_whom {
+        return true;
+    }
+
+    while let Some(who_p) = who.parent().map(|p| p.to_path_buf()) {
+        who = if let Ok(p) = fs::canonicalize(&who_p) {
+            p
+        } else {
+            who_p
+        };
+
+        if who == of_whom {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Construct string representing a human-readable size.
 ///
 /// Stolen, adapted and inlined from [fielsize.js](http://filesizejs.com).


### PR DESCRIPTION
1. `-r/--sandbox-symlinks` option to restrict access to descendants of the hosted dir (closing #71)
2. Illegal PUTs are saved into temp dir, instead of being accepted (closing #72)

<sub>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</sub>