### PR TITLE
Fix SSL-related errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = ["thecoshman <rust@thecoshman.com>",
            "pheki"]
 
 [dependencies]
-hyper-native-tls = "0.2"
+hyper-native-tls = "0.3"
 lazy_static = "1.2"
 serde_json = "0.9"
 mime_guess = "1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "1.5.0"
+version = "1.5.1"
 # Remember to also update in http.md
 authors = ["thecoshman <rust@thecoshman.com>",
            "nabijaczleweli <nabijaczleweli@gmail.com>",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.4.1-{build}
+version: 1.5.1-{build}
 
 skip_tags: false
 
@@ -22,21 +22,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v1.4.1.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.4.1.exe
-  - makensis -DHTTP_VERSION=v1.4.1 "/X!include \"EnvVarUpdate.nsh\"" install.nsi
+  - cp target\release\http.exe http-v1.5.1.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.5.1.exe
+  - makensis -DHTTP_VERSION=v1.5.1 "/X!include \"EnvVarUpdate.nsh\"" install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v1.4.1.exe
-  - path: http v1.4.1 installer.exe
+  - path: http-v1.5.1.exe
+  - path: http v1.5.1 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v1.4.1.*\.exe/
+  artifact: /http.*v1.5.1.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:


### PR DESCRIPTION
1. Bump `hyper-native-tls` to `0.3`, which, alongside [`iron` `0.6.1` doing the same thing](https://github.com/iron/iron/pull/612) means that this fixes #85 and #86

<sub>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</sub>