### PR TITLE
OSX port scan and error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "1.5.1"
+version = "1.5.2"
 # Remember to also update in http.md
 authors = ["thecoshman <rust@thecoshman.com>",
            "nabijaczleweli <nabijaczleweli@gmail.com>",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.5.1-{build}
+version: 1.5.2-{build}
 
 skip_tags: false
 
@@ -22,21 +22,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v1.5.1.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.5.1.exe
-  - makensis -DHTTP_VERSION=v1.5.1 "/X!include \"EnvVarUpdate.nsh\"" install.nsi
+  - cp target\release\http.exe http-v1.5.2.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.5.2.exe
+  - makensis -DHTTP_VERSION=v1.5.2 "/X!include \"EnvVarUpdate.nsh\"" install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v1.5.1.exe
-  - path: http v1.5.1 installer.exe
+  - path: http-v1.5.2.exe
+  - path: http v1.5.2 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v1.5.1.*\.exe/
+  artifact: /http.*v1.5.2.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
         /// This should be lowercase and imperative ("create", "open").
         op: &'static str,
         /// Additional data.
-        more: Option<Cow<'static, str>>,
+        more: Cow<'static, str>,
     },
 }
 
@@ -33,7 +33,7 @@ impl Error {
     /// Error::Io {
     ///     desc: "network",
     ///     op: "write",
-    ///     more: Some("full buffer"),
+    ///     more: "full buffer".into(),
     /// }.print_error(&mut out);
     /// assert_eq!(String::from_iter(out.iter().map(|&i| i as char)),
     ///            "Writing network failed: full buffer.\n".to_string());
@@ -47,10 +47,7 @@ impl Error {
                 } else {
                     op
                 });
-                write!(err_out, "{}ing {} failed", op, desc).unwrap();
-                if let &Some(ref more) = more {
-                    write!(err_out, ": {}", more).unwrap();
-                }
+                write!(err_out, "{}ing {} failed: {}", op, desc, more).unwrap();
                 writeln!(err_out, ".").unwrap();
             }
         }
@@ -65,7 +62,7 @@ impl Error {
     /// assert_eq!(Error::Io {
     ///     desc: "",
     ///     op: "",
-    ///     more: None,
+    ///     more: "".into(),
     /// }.exit_value(), 1);
     /// ```
     pub fn exit_value(&self) -> i32 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,73 +1,42 @@
 use self::super::util::uppercase_first;
 use std::borrow::Cow;
-use std::io::Write;
+use std::fmt;
 
 
-/// Enum representing all possible ways the application can fail.
+/// An application failure.
+///
+/// # Examples
+///
+/// ```
+/// # use https::Error;
+/// assert_eq!(Error {
+///                desc: "network",
+///                op: "write",
+///                more: "full buffer".into(),
+///            }.to_string(),
+///            "Writing network failed: full buffer.");
+/// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub enum Error {
-    /// An I/O error occured.
+pub struct Error {
+    /// The file the I/O operation regards.
+    pub desc: &'static str,
+    /// The failed operation.
     ///
-    /// This includes higher-level I/O errors like FS ones.
-    Io {
-        /// The file the I/O operation regards.
-        desc: &'static str,
-        /// The failed operation.
-        ///
-        /// This should be lowercase and imperative ("create", "open").
-        op: &'static str,
-        /// Additional data.
-        more: Cow<'static, str>,
-    },
+    /// This should be lowercase and imperative ("create", "open").
+    pub op: &'static str,
+    /// Additional data.
+    pub more: Cow<'static, str>,
 }
 
-impl Error {
-    /// Write the error message to the specified output stream.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use https::Error;
-    /// # use std::iter::FromIterator;
-    /// let mut out = Vec::new();
-    /// Error::Io {
-    ///     desc: "network",
-    ///     op: "write",
-    ///     more: "full buffer".into(),
-    /// }.print_error(&mut out);
-    /// assert_eq!(String::from_iter(out.iter().map(|&i| i as char)),
-    ///            "Writing network failed: full buffer.\n".to_string());
-    /// ```
-    pub fn print_error<W: Write>(&self, err_out: &mut W) {
-        match *self {
-            Error::Io { desc, op, ref more } => {
-                // Strip the last 'e', if any, so we get correct inflection for continuous times
-                let op = uppercase_first(if op.ends_with('e') {
-                    &op[..op.len() - 1]
-                } else {
-                    op
-                });
-                write!(err_out, "{}ing {} failed: {}", op, desc, more).unwrap();
-                writeln!(err_out, ".").unwrap();
-            }
-        }
-    }
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Strip the last 'e', if any, so we get correct inflection for continuous times
+        let op = uppercase_first(if self.op.ends_with('e') {
+            &self.op[..self.op.len() - 1]
+        } else {
+            self.op
+        });
 
-    /// Get the executable exit value from an `Error` instance.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use https::Error;
-    /// assert_eq!(Error::Io {
-    ///     desc: "",
-    ///     op: "",
-    ///     more: "".into(),
-    /// }.exit_value(), 1);
-    /// ```
-    pub fn exit_value(&self) -> i32 {
-        match *self {
-            Error::Io { .. } => 1,
-        }
+        write!(f, "{}ing {} failed: {}.", op, self.desc, self.more)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,11 +66,11 @@ fn result_main() -> Result<(), Error> {
     let mut responder = try!(if let Some(p) = opts.port {
         if let Some(&((ref id, _), ref pw)) = opts.tls_data.as_ref() {
                 Iron::new(ops::HttpHandler::new(&opts)).https(("0.0.0.0", p),
-                                                              try!(NativeTlsServer::new(id, pw).map_err(|_| {
+                                                              try!(NativeTlsServer::new(id, pw).map_err(|err| {
                     Error::Io {
                         desc: "TLS certificate",
                         op: "open",
-                        more: None,
+                        more: Some(err.to_string().into()),
                     }
                 })))
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn result_main() -> Result<(), Error> {
                     Error::Io {
                         desc: "TLS certificate",
                         op: "open",
-                        more: Some(err.to_string().into()),
+                        more: err.to_string().into(),
                     }
                 })))
             } else {
@@ -80,7 +80,7 @@ fn result_main() -> Result<(), Error> {
                 Error::Io {
                     desc: "server",
                     op: "start",
-                    more: Some("port taken".into()),
+                    more: "port taken".into(),
                 }
             })
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,6 @@ pub use error::Error;
 pub use options::Options;
 
 use iron::Iron;
-use std::io::stderr;
 use std::process::exit;
 use std::sync::{Arc, Mutex, Condvar};
 use hyper_native_tls::NativeTlsServer;
@@ -47,8 +46,8 @@ fn main() {
 
 fn actual_main() -> i32 {
     if let Err(err) = result_main() {
-        err.print_error(&mut stderr());
-        err.exit_value()
+        eprintln!("{}", err);
+        1
     } else {
         0
     }
@@ -67,7 +66,7 @@ fn result_main() -> Result<(), Error> {
         if let Some(&((ref id, _), ref pw)) = opts.tls_data.as_ref() {
                 Iron::new(ops::HttpHandler::new(&opts)).https(("0.0.0.0", p),
                                                               try!(NativeTlsServer::new(id, pw).map_err(|err| {
-                    Error::Io {
+                    Error {
                         desc: "TLS certificate",
                         op: "open",
                         more: err.to_string().into(),
@@ -77,7 +76,7 @@ fn result_main() -> Result<(), Error> {
                 Iron::new(ops::HttpHandler::new(&opts)).http(("0.0.0.0", p))
             }
             .map_err(|_| {
-                Error::Io {
+                Error {
                     desc: "server",
                     op: "start",
                     more: "port taken".into(),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1091,7 +1091,7 @@ pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16, tls_data: 
                 Error::Io {
                     desc: "TLS certificate",
                     op: "open",
-                    more: Some(err.to_string().into()),
+                    more: err.to_string().into(),
                 }
             })))
         } else {
@@ -1104,7 +1104,7 @@ pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16, tls_data: 
                     return Err(Error::Io {
                         desc: "server",
                         op: "start",
-                        more: Some(error_s.into()),
+                        more: error_s.into(),
                     });
                 }
             }
@@ -1114,7 +1114,7 @@ pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16, tls_data: 
     Err(Error::Io {
         desc: "server",
         op: "start",
-        more: Some("no free ports".into()),
+        more: "no free ports".into(),
     })
 }
 
@@ -1131,7 +1131,7 @@ pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16, tls_data: 
 /// assert_eq!(pass, "");
 /// ```
 pub fn generate_tls_data(temp_dir: &(String, PathBuf)) -> Result<((String, PathBuf), String), Error> {
-    fn err(which: bool, op: &'static str, more: Option<Cow<'static, str>>) -> Error {
+    fn err<M: Into<Cow<'static, str>>>(which: bool, op: &'static str, more: M) -> Error {
         Error::Io {
             desc: if which {
                 "TLS key generation process"
@@ -1139,7 +1139,7 @@ pub fn generate_tls_data(temp_dir: &(String, PathBuf)) -> Result<((String, PathB
                 "TLS identity generation process"
             },
             op: op,
-            more: more,
+            more: more.into(),
         }
     }
     fn exit_err(which: bool, process: &mut Child, exitc: &ExitStatus) -> Error {
@@ -1152,9 +1152,7 @@ pub fn generate_tls_data(temp_dir: &(String, PathBuf)) -> Result<((String, PathB
             stderr = "<error getting process stderr".to_string();
         }
 
-        err(which,
-            "exit",
-            Some(format!("{};\nstdout: ```\n{}```;\nstderr: ```\n{}```", exitc, stdout, stderr).into()))
+        err(which, "exit", format!("{};\nstdout: ```\n{}```;\nstderr: ```\n{}```", exitc, stdout, stderr))
     }
 
     let tls_dir = temp_dir.1.join("tls");
@@ -1163,7 +1161,7 @@ pub fn generate_tls_data(temp_dir: &(String, PathBuf)) -> Result<((String, PathB
             return Err(Error::Io {
                 desc: "temporary directory",
                 op: "create",
-                more: Some(err.to_string().into()),
+                more: err.to_string().into(),
             });
         }
     }
@@ -1175,7 +1173,7 @@ pub fn generate_tls_data(temp_dir: &(String, PathBuf)) -> Result<((String, PathB
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|error| err(true, "spawn", Some(error.to_string().into()))));
+        .map_err(|error| err(true, "spawn", error.to_string())));
     try!(child.stdin
         .as_mut()
         .unwrap()
@@ -1185,8 +1183,8 @@ pub fn generate_tls_data(temp_dir: &(String, PathBuf)) -> Result<((String, PathB
                            env!("CARGO_PKG_VERSION"),
                            "\nnabijaczleweli@gmail.com\n")
             .as_bytes())
-        .map_err(|error| err(true, "pipe", Some(error.to_string().into()))));
-    let es = try!(child.wait().map_err(|error| err(true, "wait", Some(error.to_string().into()))));
+        .map_err(|error| err(true, "pipe", error.to_string())));
+    let es = try!(child.wait().map_err(|error| err(true, "wait", error.to_string())));
     if !es.success() {
         return Err(exit_err(true, &mut child, &es));
     }
@@ -1198,8 +1196,8 @@ pub fn generate_tls_data(temp_dir: &(String, PathBuf)) -> Result<((String, PathB
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .map_err(|error| err(false, "spawn", Some(error.to_string().into()))));
-    let es = try!(child.wait().map_err(|error| err(false, "wait", Some(error.to_string().into()))));
+        .map_err(|error| err(false, "spawn", error.to_string())));
+    let es = try!(child.wait().map_err(|error| err(false, "wait", error.to_string())));
     if !es.success() {
         return Err(exit_err(false, &mut child, &es));
     }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1088,7 +1088,7 @@ pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16, tls_data: 
         match if let Some(&((_, ref id), ref pw)) = tls_data.as_ref() {
             ir.https(("0.0.0.0", port),
                      try!(NativeTlsServer::new(id, pw).map_err(|err| {
-                Error::Io {
+                Error {
                     desc: "TLS certificate",
                     op: "open",
                     more: err.to_string().into(),
@@ -1101,7 +1101,7 @@ pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16, tls_data: 
             Err(error) => {
                 let error_s = error.to_string();
                 if !error_s.contains("port") {
-                    return Err(Error::Io {
+                    return Err(Error {
                         desc: "server",
                         op: "start",
                         more: error_s.into(),
@@ -1111,7 +1111,7 @@ pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16, tls_data: 
         }
     }
 
-    Err(Error::Io {
+    Err(Error {
         desc: "server",
         op: "start",
         more: "no free ports".into(),
@@ -1132,7 +1132,7 @@ pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16, tls_data: 
 /// ```
 pub fn generate_tls_data(temp_dir: &(String, PathBuf)) -> Result<((String, PathBuf), String), Error> {
     fn err<M: Into<Cow<'static, str>>>(which: bool, op: &'static str, more: M) -> Error {
-        Error::Io {
+        Error {
             desc: if which {
                 "TLS key generation process"
             } else {
@@ -1158,7 +1158,7 @@ pub fn generate_tls_data(temp_dir: &(String, PathBuf)) -> Result<((String, PathB
     let tls_dir = temp_dir.1.join("tls");
     if !tls_dir.exists() {
         if let Err(err) = fs::create_dir_all(&tls_dir) {
-            return Err(Error::Io {
+            return Err(Error {
                 desc: "temporary directory",
                 op: "create",
                 more: err.to_string().into(),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1100,7 +1100,7 @@ pub fn try_ports<H: Handler + Clone>(hndlr: H, from: u16, up_to: u16, tls_data: 
             Ok(server) => return Ok(server),
             Err(error) => {
                 let error_s = error.to_string();
-                if !error_s.contains("port") {
+                if !error_s.contains("port") && !error_s.contains("in use") {
                     return Err(Error {
                         desc: "server",
                         op: "start",


### PR DESCRIPTION
1. Properly handle OSX's "Address already in use (os error 48)." error message. Fixes #88
2. Improved error handling to always include error info

<sub>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</sub>