### PR TITLE
Redirect impermanence, bracket escaping, cross-libc builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "1.10.0"
+version = "1.10.1"
 # Remember to also update in http.md
 authors = ["thecoshman <rust@thecoshman.com>",
            "nabijaczleweli <nabijaczleweli@nabijaczleweli.xyz>",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,11 @@ install:
   - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%;C:\Users\appveyor\.cargo\bin
   # https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported
   - curl -SL http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz -oC:\msys2-keyring.txz
+  - curl -SL http://repo.msys2.org/msys/x86_64/zstd-1.4.4-1-x86_64.pkg.tar.xz -oC:\zstd.txz
+  - curl -SL http://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz -oC:\pacman.txz
   - pacman --noconfirm -U C:\msys2-keyring.txz
+  - pacman --noconfirm -U C:\zstd.txz
+  - pacman --noconfirm -U C:\pacman.txz
   - bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - bash -lc "pacman --noconfirm -Sy pacman"
   - bash -lc "pacman --noconfirm -Su"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.10.0-{build}
+version: 1.10.1-{build}
 
 skip_tags: false
 
@@ -32,21 +32,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v1.10.0.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.10.0.exe
-  - makensis -DHTTP_VERSION=v1.10.0 install.nsi
+  - cp target\release\http.exe http-v1.10.1.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.10.1.exe
+  - makensis -DHTTP_VERSION=v1.10.1 install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v1.10.0.exe
-  - path: http v1.10.0 installer.exe
+  - path: http-v1.10.1.exe
+  - path: http v1.10.1 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v1.10.0.*\.exe/
+  artifact: /http.*v1.10.1.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -740,7 +740,7 @@ impl HttpHandler {
         //     https://cloud.githubusercontent.com/assets/6709544/21442017/9eb20d64-c89b-11e6-8c7b-888b5f70a403.png
         //   - With following slash:
         //     https://cloud.githubusercontent.com/assets/6709544/21442028/a50918c4-c89b-11e6-8936-c29896947f6a.png
-        Ok(Response::with((status::MovedPermanently, Header(headers::Server(USER_AGENT.to_string())), Header(headers::Location(new_url)))))
+        Ok(Response::with((status::SeeOther, Header(headers::Server(USER_AGENT.to_string())), Header(headers::Location(new_url)))))
     }
 
     fn handle_get_mobile_dir_listing(&self, req: &mut Request, req_p: PathBuf) -> IronResult<Response> {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -763,7 +763,7 @@ impl HttpHandler {
                     file_time_modified_p(req_p.parent().expect("Failed to get requested directory's parent directory"))
                         .strftime("%F %T")
                         .unwrap(),
-                    up_path = slash_idx.map(|i| &rel_noslash[0..i]).unwrap_or(""),
+                    up_path = slash_idx.map(|i| &rel_noslash[0..i]).unwrap_or("").replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"),
                     up_path_slash = if slash_idx.is_some() { "/" } else { "" })
         };
         let list_s = req_p.read_dir()
@@ -815,8 +815,8 @@ impl HttpHandler {
                         } else {
                             DisplayThree("", String::new(), "")
                         },
-                        path = format!("/{}", relpath).replace("//", "/").replace('%', "%25").replace('#', "%23"),
-                        fname = fname.replace('%', "%25").replace('#', "%23"))
+                        path = format!("/{}", relpath).replace("//", "/").replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"),
+                        fname = fname.replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"))
             });
 
         self.handle_generated_response_encoding(req,
@@ -866,7 +866,7 @@ impl HttpHandler {
                          <td><a href=\"/{up_path}{up_path_slash}\">&nbsp;</a></td> \
                          <td><a href=\"/{up_path}{up_path_slash}\">&nbsp;</a></td></tr>",
                     file_time_modified_p(req_p.parent().expect("Failed to get requested directory's parent directory")).strftime("%F %T").unwrap(),
-                    up_path = slash_idx.map(|i| &rel_noslash[0..i]).unwrap_or(""),
+                    up_path = slash_idx.map(|i| &rel_noslash[0..i]).unwrap_or("").replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"),
                     up_path_slash = if slash_idx.is_some() { "/" } else { "" })
         };
 
@@ -930,8 +930,8 @@ impl HttpHandler {
                         } else {
                             DisplayThree("", "", "")
                         },
-                        path = format!("/{}", relpath).replace("//", "/").replace('%', "%25").replace('#', "%23"),
-                        fname = fname.replace('%', "%25").replace('#', "%23"))
+                        path = format!("/{}", relpath).replace("//", "/").replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"),
+                        fname = fname.replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"))
             });
 
         self.handle_generated_response_encoding(req,


### PR DESCRIPTION
1. Redirects from `owo/awa` to `owo/awa/` now SeeOther instead of MovedPermanently
2. `[` and `]` are escaped in links in generated indices (#119)
3. Cross-compilation across libcs should now work (#120)
4. AppVeyor builds fixed again

<small>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</small>