### PR TITLE
Added option -l --no-listings

### DIFF
--- a/http.md
+++ b/http.md
@@ -166,10 +166,31 @@ pass parameters like what port to use.
     This is false by default because it's most likely not something you
     want to do.
 
+  -l --no-listings
+
+    Do not generate directory listings.
+
+    Behaviour table of `--no-listing`(-l) with `--no-indices`(-i)
+    +------------+---------+---------+---------+---------+
+    |    Path    | Neither |   -i    |   -l    |  -l -i  |
+    +============+=========+=========+=========+=========+
+    | /has-index |  index  | listing |  index  |   404   |
+    | /no-index  | listing | listing |   404   |   404   |
+    +------------+---------+---------+---------+---------+
+
+    This is false by default because it's most likely for debugging purposes.
+
   -i --no-indices
 
-    Always generate directory listings, even for directories containing an
-    index file.
+    Do not automatically serve the index file for directories containing one.
+
+    Behaviour table of `--no-listing`(-l) with `--no-indices`(-i)
+    +------------+---------+---------+---------+---------+
+    |    Path    | Neither |   -i    |   -l    |  -l -i  |
+    +============+=========+=========+=========+=========+
+    | /has-index |  index  | listing |  index  |   404   |
+    | /no-index  | listing | listing |   404   |   404   |
+    +------------+---------+---------+---------+---------+
 
     This is false by default because it's most likely for debugging purposes.
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -115,6 +115,7 @@ pub struct HttpHandler {
     pub hosted_directory: (String, PathBuf),
     pub follow_symlinks: bool,
     pub sandbox_symlinks: bool,
+    pub serve_listings: bool,
     pub check_indices: bool,
     pub strip_extensions: bool,
     /// (at all, log_colour)
@@ -153,6 +154,7 @@ impl HttpHandler {
             hosted_directory: opts.hosted_directory.clone(),
             follow_symlinks: opts.follow_symlinks,
             sandbox_symlinks: opts.sandbox_symlinks,
+            serve_listings: opts.serve_listings,
             check_indices: opts.check_indices,
             strip_extensions: opts.strip_extensions,
             log: (opts.loglevel < LogLevel::NoServeStatus, opts.log_colour),
@@ -1326,6 +1328,7 @@ impl Clone for HttpHandler {
             hosted_directory: self.hosted_directory.clone(),
             follow_symlinks: self.follow_symlinks,
             sandbox_symlinks: self.sandbox_symlinks,
+            serve_listings: self.serve_listings,
             check_indices: self.check_indices,
             strip_extensions: self.strip_extensions,
             log: self.log,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -721,6 +721,10 @@ impl HttpHandler {
             }
         }
 
+        if !self.serve_listings {
+            return self.handle_nonexistent(req, req_p);
+        }
+
         if client_mobile(&req.headers) {
             self.handle_get_mobile_dir_listing(req, req_p)
         } else {

--- a/src/options.rs
+++ b/src/options.rs
@@ -76,8 +76,19 @@ pub struct Options {
     /// The temp directory to write to before copying to hosted directory and to store encoded FS responses.
     /// Default: `"$TEMP/http-[FULL_PATH_TO_HOSTED_DIR]"`
     pub temp_directory: (String, PathBuf),
+
+    // Behaviour table of `serve_listings`(L) with `check_indices`(I)
+    // +------------+---------+---------+---------+---------+
+    // |    Path    | L:t I:t | L:t I:f | L:f I:t | L:f I:f |
+    // +============+=========+=========+=========+=========+
+    // | /has-index |  index  | listing |  index  |   404   |
+    // | /no-index  | listing | listing |   404   |   404   |
+    // +------------+---------+---------+---------+---------+
+    /// Whether to serve listings at all. Default: true
+    pub serve_listings: bool,
     /// Whether to check for index files in served directories before serving a listing. Default: true
     pub check_indices: bool,
+
     /// Whether to allow requests to `/file` to return `/file.{INDEX_EXTENSIONS`. Default: false
     pub strip_extensions: bool,
     /// Whether to allow write operations. Default: false
@@ -128,7 +139,8 @@ impl Options {
             .arg(Arg::from_usage("-r --sandbox-symlinks 'Restrict/sandbox where symlinks lead to only the direct descendants of the hosted directory. \
                                   Default: false'"))
             .arg(Arg::from_usage("-w --allow-write 'Allow for write operations. Default: false'"))
-            .arg(Arg::from_usage("-i --no-indices 'Always generate dir listings even if index files are available. Default: false'"))
+            .arg(Arg::from_usage("-l --no-listings 'Never generate dir listings. Default: false'"))
+            .arg(Arg::from_usage("-i --no-indices 'Do not automatically use index files. Default: false'"))
             .arg(Arg::from_usage("-e --no-encode 'Do not encode filesystem files. Default: false'"))
             .arg(Arg::from_usage("-x --strip-extensions 'Allow stripping index extentions from served paths. Default: false'"))
             .arg(Arg::from_usage("-q --quiet... 'Suppress increasing amounts of output'"))
@@ -210,6 +222,7 @@ impl Options {
                          suffix),
                  temp_pb.join(suffix))
             },
+            serve_listings: !matches.is_present("no-listings"),
             check_indices: !matches.is_present("no-indices"),
             strip_extensions: matches.is_present("strip-extensions"),
             allow_writes: matches.is_present("allow-write"),


### PR DESCRIPTION
A flag that prevents the server from generating listings, and instead returns 404.

Works well with -i --no-indices (+ documentation).