### PR TITLE
Multi-binary clarifications, --no-listings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,13 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "1.10.1"
+version = "1.11.0"
 # Remember to also update in http.md
 authors = ["thecoshman <rust@thecoshman.com>",
            "nabijaczleweli <nabijaczleweli@nabijaczleweli.xyz>",
            "pheki",
-           "Adrian Herath <adrianisuru@gmail.com>"]
+           "Adrian Herath <adrianisuru@gmail.com>",
+           "cyqsimon"]
 
 [dependencies]
 hyper-native-tls = "0.3"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you have `cargo` installed (you're a Rust developer) all you need to do is:
 cargo install https
 ```
 
-Which will install `http` in the folder where all other binaries go.
+Which will install `http` and `httplz` (identical, disable one or another if they clash) in the folder where all other binaries go.
 
 If, however, you're not a Rust developer, but you have `sh`-like shell, you can use an installer (works on Windows and Linux):
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%;C:\Users\appveyor\.cargo\bin
   # https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported
   - curl -SL http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz -oC:\msys2-keyring.txz
-  - curl -SL http://repo.msys2.org/msys/x86_64/zstd-1.4.4-1-x86_64.pkg.tar.xz -oC:\zstd.txz
+  - curl -SL http://repo.msys2.org/msys/x86_64/zstd-1.4.4-2-x86_64.pkg.tar.xz -oC:\zstd.txz
   - curl -SL http://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz -oC:\pacman.txz
   - pacman --noconfirm -U C:\msys2-keyring.txz
   - pacman --noconfirm -U C:\zstd.txz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.10.1-{build}
+version: 1.11.0-{build}
 
 skip_tags: false
 
@@ -32,21 +32,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v1.10.1.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.10.1.exe
-  - makensis -DHTTP_VERSION=v1.10.1 install.nsi
+  - cp target\release\http.exe http-v1.11.0.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.11.0.exe
+  - makensis -DHTTP_VERSION=v1.11.0 install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v1.10.1.exe
-  - path: http v1.10.1 installer.exe
+  - path: http-v1.11.0.exe
+  - path: http v1.11.0 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v1.10.1.*\.exe/
+  artifact: /http.*v1.11.0.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:

--- a/http.md
+++ b/http.md
@@ -452,7 +452,8 @@ pass parameters like what port to use.
 Written by thecoshman &lt;<rust@thecoshman.com>&gt;,
            nabijaczleweli &lt;<nabijaczleweli@nabijaczleweli.xyz>&gt;,
            pheki,
-       and Adrian Herath &lt;<adrianisuru@gmail.com>&gt;.
+           Adrian Herath &lt;<adrianisuru@gmail.com>&gt;,
+       and cyqsimon.
 
 ## REPORTING BUGS
 

--- a/http.md
+++ b/http.md
@@ -166,10 +166,23 @@ pass parameters like what port to use.
     This is false by default because it's most likely not something you
     want to do.
 
+  -l --no-listings
+
+    Do not generate directory listings.
+
+    Behaviour table of --no-listings with --no-indices:
+    +------------+---------+---------+---------+---------+
+    |    Path    | Neither |   -i    |   -l    |  -l -i  |
+    +============+=========+=========+=========+=========+
+    | /has-index |  index  | listing |  index  |   404   |
+    | /no-index  | listing | listing |   404   |   404   |
+    +------------+---------+---------+---------+---------+
+
+    This is false by default because it's most likely for debugging purposes.
+
   -i --no-indices
 
-    Always generate directory listings, even for directories containing an
-    index file.
+    Do not automatically serve the index file for directories containing one.
 
     This is false by default because it's most likely for debugging purposes.
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -721,6 +721,10 @@ impl HttpHandler {
             }
         }
 
+        if !self.generate_listings {
+            return self.handle_nonexistent(req, req_p);
+        }
+
         if client_mobile(&req.headers) {
             self.handle_get_mobile_dir_listing(req, req_p)
         } else {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -115,6 +115,7 @@ pub struct HttpHandler {
     pub hosted_directory: (String, PathBuf),
     pub follow_symlinks: bool,
     pub sandbox_symlinks: bool,
+    pub generate_listings: bool,
     pub check_indices: bool,
     pub strip_extensions: bool,
     /// (at all, log_colour)
@@ -153,6 +154,7 @@ impl HttpHandler {
             hosted_directory: opts.hosted_directory.clone(),
             follow_symlinks: opts.follow_symlinks,
             sandbox_symlinks: opts.sandbox_symlinks,
+            generate_listings: opts.generate_listings,
             check_indices: opts.check_indices,
             strip_extensions: opts.strip_extensions,
             log: (opts.loglevel < LogLevel::NoServeStatus, opts.log_colour),
@@ -1326,6 +1328,7 @@ impl Clone for HttpHandler {
             hosted_directory: self.hosted_directory.clone(),
             follow_symlinks: self.follow_symlinks,
             sandbox_symlinks: self.sandbox_symlinks,
+            generate_listings: self.generate_listings,
             check_indices: self.check_indices,
             strip_extensions: self.strip_extensions,
             log: self.log,

--- a/src/options.rs
+++ b/src/options.rs
@@ -76,6 +76,8 @@ pub struct Options {
     /// The temp directory to write to before copying to hosted directory and to store encoded FS responses.
     /// Default: `"$TEMP/http-[FULL_PATH_TO_HOSTED_DIR]"`
     pub temp_directory: (String, PathBuf),
+    /// Whether to generate directory listings at all. Default: true
+    pub generate_listings: bool,
     /// Whether to check for index files in served directories before serving a listing. Default: true
     pub check_indices: bool,
     /// Whether to allow requests to `/file` to return `/file.{INDEX_EXTENSIONS`. Default: false
@@ -128,7 +130,8 @@ impl Options {
             .arg(Arg::from_usage("-r --sandbox-symlinks 'Restrict/sandbox where symlinks lead to only the direct descendants of the hosted directory. \
                                   Default: false'"))
             .arg(Arg::from_usage("-w --allow-write 'Allow for write operations. Default: false'"))
-            .arg(Arg::from_usage("-i --no-indices 'Always generate dir listings even if index files are available. Default: false'"))
+            .arg(Arg::from_usage("-l --no-listings 'Never generate dir listings. Default: false'"))
+            .arg(Arg::from_usage("-i --no-indices 'Do not automatically use index files. Default: false'"))
             .arg(Arg::from_usage("-e --no-encode 'Do not encode filesystem files. Default: false'"))
             .arg(Arg::from_usage("-x --strip-extensions 'Allow stripping index extentions from served paths. Default: false'"))
             .arg(Arg::from_usage("-q --quiet... 'Suppress increasing amounts of output'"))
@@ -210,6 +213,7 @@ impl Options {
                          suffix),
                  temp_pb.join(suffix))
             },
+            generate_listings: !matches.is_present("no-listings"),
             check_indices: !matches.is_present("no-indices"),
             strip_extensions: matches.is_present("strip-extensions"),
             allow_writes: matches.is_present("allow-write"),


### PR DESCRIPTION
1. Clarification the README regarding multiple binaries (https://github.com/thecoshman/http/issues/35#issuecomment-769013268)
2. `--no-listings` (#122)
3. Also I fixed AppVeyor again

<small>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</small>