### PR TITLE
--gen-ssl, just like momma used to make

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "1.11.1"
+version = "1.11.2"
 # Remember to also update in http.md
 authors = ["thecoshman <rust@thecoshman.com>",
            "nabijaczleweli <nabijaczleweli@nabijaczleweli.xyz>",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ install:
   - pacman --noconfirm -U C:\pacman.txz
   - bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - bash -lc "pacman --noconfirm -Sy pacman"
+  - bash -lc "pacman --noconfirm -Sy"
   - bash -lc "pacman --noconfirm -Su"
   - bash -lc "pacman --noconfirm -Sy"
   - bash -lc "pacman --noconfirm -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-nsis unzip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.11.1-{build}
+version: 1.11.2-{build}
 
 skip_tags: false
 
@@ -33,21 +33,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v1.11.1.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.11.1.exe
-  - makensis -DHTTP_VERSION=v1.11.1 install.nsi
+  - cp target\release\http.exe http-v1.11.2.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.11.2.exe
+  - makensis -DHTTP_VERSION=v1.11.2 install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v1.11.1.exe
-  - path: http v1.11.1 installer.exe
+  - path: http-v1.11.2.exe
+  - path: http v1.11.2 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v1.11.1.*\.exe/
+  artifact: /http.*v1.11.2.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:

--- a/http.md
+++ b/http.md
@@ -57,12 +57,12 @@ pass parameters like what port to use.
 
   --gen-ssl
 
-    Generate a passwordless, single-use TLS self-signed certificate
+    Generate a single-use self-signed TLS certificate
     and use it for this session.
 
-    On MacOS the certificate does actually have a password, password,
-    because the platform libssl implementation refuses to import
-    PKCS12 certificates without one.
+    The password for the certificate is the empty string,
+    except on MacOS, where it's "password", since the platform libssl
+    refuses to import passwordless certificates.
 
     Exclusive with --ssl. Default: false.
 

--- a/http.md
+++ b/http.md
@@ -60,6 +60,10 @@ pass parameters like what port to use.
     Generate a passwordless, single-use TLS self-signed certificate
     and use it for this session.
 
+    On MacOS the certificate does actually have a password, password,
+    because the platform libssl implementation refuses to import
+    PKCS12 certificates without one.
+
     Exclusive with --ssl. Default: false.
 
   --auth [USERNAME[:PASSWORD]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn result_main() -> Result<(), Error> {
         after: opts.request_bandwidth.map(ops::LimitBandwidthMiddleware::new),
     };
     let mut responder = if let Some(p) = opts.port {
-        if let Some(&((ref id, _), ref pw)) = opts.tls_data.as_ref() {
+        if let Some(&((_, ref id), ref pw)) = opts.tls_data.as_ref() {
                 Iron::new(handler).https((opts.bind_address, p),
                                          NativeTlsServer::new(id, pw).map_err(|err| {
                         Error {


### PR DESCRIPTION
1. Fix for --gen-ssl on MacOS (#86)
2. Fix for --gen-ssl combined with --port
3. AppVeyor decided to break again

<small>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</small>