### PR TITLE
multi-value arguments SNAFU, escapes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ authors = ["thecoshman <rust@thecoshman.com>",
            "nabijaczleweli <nabijaczleweli@nabijaczleweli.xyz>",
            "pheki",
            "Adrian Herath <adrianisuru@gmail.com>",
-           "cyqsimon"]
+           "cyqsimon",
+           "jim4067"]
 
 [dependencies]
 hyper-native-tls = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "1.12.1"
+version = "1.12.2"
 # Remember to also update in http.md
 authors = ["thecoshman <rust@thecoshman.com>",
            "nabijaczleweli <nabijaczleweli@nabijaczleweli.xyz>",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# http [![Travis build status](https://travis-ci.org/thecoshman/http.svg)](https://travis-ci.org/thecoshman/http) [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/7knk9lnptn1njro5?svg=true)](https://ci.appveyor.com/project/thecoshman/http) [![Licence](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE) [![Crates.io version](https://meritbadge.herokuapp.com/https)](https://crates.io/crates/https)
+# http [![Travis build status](https://travis-ci.org/thecoshman/http.svg)](https://travis-ci.org/thecoshman/http) [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/7knk9lnptn1njro5?svg=true)](https://ci.appveyor.com/project/thecoshman/http) [![Licence](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE) [![Crates.io version](https://img.shields.io/crates/v/https.svg)](https://crates.io/crates/https)
 Host These Things Please - a basic HTTP server for hosting a folder fast and simply
 
 ## Selected features

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.12.1-{build}
+version: 1.12.2-{build}
 
 skip_tags: false
 
@@ -33,21 +33,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v1.12.1.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.12.1.exe
-  - makensis -DHTTP_VERSION=v1.12.1 install.nsi
+  - cp target\release\http.exe http-v1.12.2.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.12.2.exe
+  - makensis -DHTTP_VERSION=v1.12.2 install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v1.12.1.exe
-  - path: http v1.12.1 installer.exe
+  - path: http-v1.12.2.exe
+  - path: http v1.12.2 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v1.12.1.*\.exe/
+  artifact: /http.*v1.12.2.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,13 @@ install:
   - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%;C:\Users\appveyor\.cargo\bin
   # https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported
   - curl -SL http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz -oC:\msys2-keyring.txz
-  - curl -SL http://repo.msys2.org/msys/x86_64/zstd-1.4.4-2-x86_64.pkg.tar.xz -oC:\zstd.txz
+  - curl -SL http://repo.msys2.org/msys/x86_64/msys2-keyring-1~20210904-1-any.pkg.tar.zst -oC:\msys2-keyring.tzst
+  - curl -SL http://repo.msys2.org/msys/x86_64/zstd-1.4.7-1-x86_64.pkg.tar.xz -oC:\zstd.txz
   - curl -SL http://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz -oC:\pacman.txz
   - pacman --noconfirm -U C:\msys2-keyring.txz
   - pacman --noconfirm -U C:\zstd.txz
   - pacman --noconfirm -U C:\pacman.txz
+  - pacman --noconfirm -U C:\msys2-keyring.tzst
   - bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - bash -lc "pacman --noconfirm -Sy pacman"
   - bash -lc "pacman --noconfirm -Sy"

--- a/http.md
+++ b/http.md
@@ -463,7 +463,8 @@ Written by thecoshman &lt;<rust@thecoshman.com>&gt;,
            nabijaczleweli &lt;<nabijaczleweli@nabijaczleweli.xyz>&gt;,
            pheki,
            Adrian Herath &lt;<adrianisuru@gmail.com>&gt;,
-       and cyqsimon.
+           cyqsimon,
+       and jim4067.
 
 ## REPORTING BUGS
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -809,7 +809,7 @@ impl HttpHandler {
                         if is_file { "file" } else { "dir" },
                         file_icon_suffix(&path, is_file),
                         path.file_name().map(|p| p.to_str().expect("Filename not UTF-8").replace('.', "_")).as_ref().unwrap_or(&fname),
-                        fname.replace('<', "&lt;"),
+                        fname.replace('&', "&amp;").replace('<', "&lt;"),
                         if is_file { "" } else { "/" },
                         if show_file_management_controls {
                             DisplayThree("<span class=\"manage\"><span class=\"delete_file_icon\">Delete</span>",
@@ -919,7 +919,7 @@ impl HttpHandler {
                         path.file_name().map(|p| p.to_str().expect("Filename not UTF-8").replace('.', "_")).as_ref().unwrap_or(&fname),
                         if is_file { "file" } else { "dir" },
                         file_icon_suffix(&path, is_file),
-                        fname.replace('<', "&lt;"),
+                        fname.replace('&', "&amp;").replace('<', "&lt;"),
                         if is_file { "" } else { "/" },
                         file_time_modified(&fmeta).strftime("%F %T").unwrap(),
                         if is_file {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -27,7 +27,7 @@ use iron::mime::{Mime, SubLevel as MimeSubLevel, TopLevel as MimeTopLevel};
 use std::io::{self, ErrorKind as IoErrorKind, SeekFrom, Write, Error as IoError, Read, Seek};
 use iron::{headers, status, method, mime, IronResult, Listening, Response, TypeMap, Request, Handler, Iron};
 use self::super::util::{WwwAuthenticate, DisplayThree, CommaList, Spaces, Dav, url_path, file_hash, is_symlink, encode_str, encode_file, file_length,
-                        hash_string, html_response, file_binary, client_mobile, percent_decode, file_icon_suffix, is_actually_file, is_descendant_of,
+                        hash_string, html_response, file_binary, client_mobile, percent_decode, escape_specials, file_icon_suffix, is_actually_file, is_descendant_of,
                         response_encoding, detect_file_as_dir, encoding_extension, file_time_modified, file_time_modified_p, get_raw_fs_metadata,
                         human_readable_size, encode_tail_if_trimmed, is_nonexistent_descendant_of, USER_AGENT, ERROR_HTML, INDEX_EXTENSIONS, MIN_ENCODING_GAIN,
                         MAX_ENCODING_SIZE, MIN_ENCODING_SIZE, DAV_LEVEL_1_METHODS, DIRECTORY_LISTING_HTML, MOBILE_DIRECTORY_LISTING_HTML,
@@ -775,8 +775,7 @@ impl HttpHandler {
                     file_time_modified_p(req_p.parent().expect("Failed to get requested directory's parent directory"))
                         .strftime("%F %T")
                         .unwrap(),
-                    up_path =
-                        slash_idx.map(|i| &rel_noslash[0..i]).unwrap_or("").replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"),
+                    up_path = escape_specials(slash_idx.map(|i| &rel_noslash[0..i]).unwrap_or("")),
                     up_path_slash = if slash_idx.is_some() { "/" } else { "" })
         };
         let list_s = req_p.read_dir()
@@ -828,8 +827,8 @@ impl HttpHandler {
                         } else {
                             DisplayThree("", String::new(), "")
                         },
-                        path = format!("/{}", relpath).replace("//", "/").replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"),
-                        fname = encode_tail_if_trimmed(fname.replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D")))
+                        path = escape_specials(format!("/{}", relpath).replace("//", "/")),
+                        fname = encode_tail_if_trimmed(escape_specials(&fname)))
             });
 
         self.handle_generated_response_encoding(req,
@@ -879,8 +878,7 @@ impl HttpHandler {
                          <td><a href=\"/{up_path}{up_path_slash}\">&nbsp;</a></td> \
                          <td><a href=\"/{up_path}{up_path_slash}\">&nbsp;</a></td></tr>",
                     file_time_modified_p(req_p.parent().expect("Failed to get requested directory's parent directory")).strftime("%F %T").unwrap(),
-                    up_path =
-                        slash_idx.map(|i| &rel_noslash[0..i]).unwrap_or("").replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"),
+                    up_path = escape_specials(slash_idx.map(|i| &rel_noslash[0..i]).unwrap_or("")),
                     up_path_slash = if slash_idx.is_some() { "/" } else { "" })
         };
 
@@ -944,8 +942,8 @@ impl HttpHandler {
                         } else {
                             DisplayThree("", "", "")
                         },
-                        path = format!("/{}", relpath).replace("//", "/").replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D"),
-                        fname = encode_tail_if_trimmed(fname.replace('%', "%25").replace('#', "%23").replace('[', "%5B").replace(']', "%5D")))
+                        path = escape_specials(format!("/{}", relpath).replace("//", "/")),
+                        fname = encode_tail_if_trimmed(escape_specials(&fname)))
             });
 
         self.handle_generated_response_encoding(req,

--- a/src/ops/webdav.rs
+++ b/src/ops/webdav.rs
@@ -329,7 +329,7 @@ impl HttpHandler {
                 return Ok(Response::with(status::PreconditionFailed));
             }
 
-            if !is_actually_file(&dest_p.metadata().expect("Failed to get destination file metadata").file_type()) {
+            if !is_actually_file(&dest_p.metadata().expect("Failed to get destination file metadata").file_type(), &dest_p) {
                 // NB: this disallows overwriting non-empty directories
                 if fs::remove_dir(&dest_p).is_err() {
                     return Ok(Response::with(status::Locked));
@@ -339,7 +339,7 @@ impl HttpHandler {
             overwritten = true;
         }
 
-        let source_file = is_actually_file(&req_p.metadata().expect("Failed to get requested file metadata").file_type());
+        let source_file = is_actually_file(&req_p.metadata().expect("Failed to get requested file metadata").file_type(), &dest_p);
         if let Some(sp) = source_path {
             *sp = (req_p.clone(), source_file);
         }
@@ -463,7 +463,7 @@ impl HttpHandler {
 
                 "resourcetype" => {
                     out.write(XmlWEvent::start_element((WEBDAV_XML_NAMESPACE_DAV.0, "resourcetype")))?;
-                    if !is_actually_file(&meta.file_type()) {
+                    if !is_actually_file(&meta.file_type(), path) {
                         out.write(XmlWEvent::start_element((WEBDAV_XML_NAMESPACE_DAV.0, "collection")))?;
                         out.write(XmlWEvent::end_element())?;
                     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -146,15 +146,20 @@ impl Options {
             .arg(Arg::from_usage("--auth [USERNAME[:PASSWORD]] 'Data for global authentication'").validator(Options::credentials_validator))
             .arg(Arg::from_usage("--gen-auth 'Generate a one-off username:password set for global authentication'").conflicts_with("auth"))
             .arg(Arg::from_usage("--path-auth [PATH=[USERNAME[:PASSWORD]]]... 'Data for authentication under PATH'")
+                .use_delimiter(false)
                 .validator(Options::path_credentials_validator))
-            .arg(Arg::from_usage("--gen-path-auth [PATH]... 'Generate a one-off username:password set for authentication under PATH'"))
+            .arg(Arg::from_usage("--gen-path-auth [PATH]... 'Generate a one-off username:password set for authentication under PATH'").use_delimiter(false))
             .arg(Arg::from_usage("--proxy [HEADER-NAME:CIDR]... 'Treat HEADER-NAME as proxy forwarded-for header when request comes from CIDR'")
+                .use_delimiter(false)
                 .validator(|s| Options::proxy_parse(s.into()).map(|_| ())))
             .arg(Arg::from_usage("-m --mime-type [EXTENSION:MIME-TYPE]... 'Always return MIME-TYPE for files with EXTENSION'")
+                .use_delimiter(false)
                 .validator(|s| Options::mime_type_override_parse(s.into()).map(|_| ())))
             .arg(Arg::from_usage("--request-bandwidth [BYTES] 'Limit each request to returning BYTES per second, or 0 for unlimited. Default: 0'")
                 .validator(|s| Options::bandwidth_parse(s.into()).map(|_| ())))
-            .arg(Arg::from_usage("-H --header [NAME: VALUE]... 'Headers to add to every response'").validator(|s| Options::header_parse(&s).map(|_| ())))
+            .arg(Arg::from_usage("-H --header [NAME: VALUE]... 'Headers to add to every response'")
+                .use_delimiter(false)
+                .validator(|s| Options::header_parse(&s).map(|_| ())))
             .get_matches();
 
         let dir = matches.value_of("DIR").unwrap_or(".");

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -240,6 +240,23 @@ pub fn encode_tail_if_trimmed(mut s: String) -> String {
     }
 }
 
+/// %-escape special characters in an URL
+pub fn escape_specials<S: AsRef<str>>(s: S) -> String {
+    let s = s.as_ref();
+    let mut ret = Vec::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        match b {
+            b'%' => ret.extend(b"%25"),
+            b'#' => ret.extend(b"%23"),
+            b'?' => ret.extend(b"%3F"),
+            b'[' => ret.extend(b"%5B"),
+            b']' => ret.extend(b"%5D"),
+            _ => ret.push(b),
+        }
+    }
+    unsafe { String::from_utf8_unchecked(ret) }
+}
+
 /// Check if the specified file is to be considered "binary".
 ///
 /// Basically checks is a file is UTF-8.

--- a/src/util/os/non_windows.rs
+++ b/src/util/os/non_windows.rs
@@ -24,7 +24,7 @@ pub fn win32_file_attributes(meta: &Metadata, path: &Path) -> u32 {
         attr |= FILE_ATTRIBUTE_HIDDEN;
     }
 
-    if !is_actually_file(&meta.file_type()) {
+    if !is_actually_file(&meta.file_type(), &path) {
         attr |= FILE_ATTRIBUTE_DIRECTORY;
     } else {
         // this is the 'Archive' bit, which is set by


### PR DESCRIPTION
1. `-H` et al. accepted comma-separated values despite the documented `clap` default (#136)
2. Dead meritbadge link (#135)
3. unescaped `&`s (pursuant to #133)
4. Proper distinguishing between files and directories hiding behind symlinks; before: ![screenshot with amix.x5.tgz showing up as a directory](https://user-images.githubusercontent.com/6709544/145629885-4ffa7f13-2ffa-43d1-bfcc-dc7e7ac908e3.png) vs after: 
![as a file](https://user-images.githubusercontent.com/6709544/145629940-04696e9e-448e-4f3d-9624-9835f0991d6e.png)
5. Escaped `?`s



<small>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</small>