### PR TITLE
Explicit OpenSSL requirement, {un,}compressed unreadable file parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "1.12.4"
+version = "1.12.5"
 # Remember to also update in http.md
 authors = ["thecoshman <rust@thecoshman.com>",
            "nabijaczleweli <nabijaczleweli@nabijaczleweli.xyz>",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%;C:\Users\appveyor\.cargo\bin
   # https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported
   - curl -SL http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz -oC:\msys2-keyring.txz
-  - curl -SL http://repo.msys2.org/msys/x86_64/msys2-keyring-1~20210904-1-any.pkg.tar.zst -oC:\msys2-keyring.tzst
+  - curl -SL http://repo.msys2.org/msys/x86_64/msys2-keyring-1~20211228-1-any.pkg.tar.zst -oC:\msys2-keyring.tzst
   - curl -SL http://repo.msys2.org/msys/x86_64/zstd-1.4.7-1-x86_64.pkg.tar.xz -oC:\zstd.txz
   - curl -SL http://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz -oC:\pacman.txz
   - pacman --noconfirm -U C:\msys2-keyring.txz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.12.4-{build}
+version: 1.12.5-{build}
 
 skip_tags: false
 
@@ -35,21 +35,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v1.12.4.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.12.4.exe
-  - makensis -DHTTP_VERSION=v1.12.4 install.nsi
+  - cp target\release\http.exe http-v1.12.5.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v1.12.5.exe
+  - makensis -DHTTP_VERSION=v1.12.5 install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v1.12.4.exe
-  - path: http v1.12.4 installer.exe
+  - path: http-v1.12.5.exe
+  - path: http v1.12.5 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v1.12.4.*\.exe/
+  artifact: /http.*v1.12.5.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:

--- a/http.md
+++ b/http.md
@@ -58,7 +58,7 @@ pass parameters like what port to use.
   --gen-ssl
 
     Generate a single-use self-signed TLS certificate
-    and use it for this session.
+    with openssl and use it for this session.
 
     The password for the certificate is the empty string,
     except on MacOS, where it's "password", since the platform libssl

--- a/src/util/content_encoding.rs
+++ b/src/util/content_encoding.rs
@@ -2,11 +2,11 @@ use brotli::enc::backward_references::{BrotliEncoderParams, BrotliEncoderMode};
 use brotli::enc::BrotliCompress as brotli_compress;
 use flate2::write::{DeflateEncoder, GzEncoder};
 use flate2::Compression as Flate2Compression;
+use std::io::{self, Error as IoError, Write};
 use iron::headers::{QualityItem, Encoding};
 use bzip2::Compression as BzCompression;
 use std::collections::BTreeSet;
 use bzip2::write::BzEncoder;
-use std::io::{self, Write};
 use unicase::UniCase;
 use std::path::Path;
 use std::fs::File;
@@ -80,10 +80,10 @@ pub fn encoding_extension(enc: &Encoding) -> Option<&'static str> {
 }
 
 /// Return the 256-bit BLAKE3 hash of the file denoted by the specified path.
-pub fn file_hash(p: &Path) -> blake3::Hash {
+pub fn file_hash(p: &Path) -> Result<blake3::Hash, IoError> {
     let mut ctx = blake3::Hasher::new();
-    io::copy(&mut File::open(p).unwrap(), &mut ctx).unwrap();
-    ctx.finalize()
+    io::copy(&mut File::open(p)?, &mut ctx)?;
+    Ok(ctx.finalize())
 }
 
 


### PR DESCRIPTION
1. Notes openssl requirement explicitly (#146)
2. Fixes AppVeyor
3. Fixes unreadable file (e.g. via EPERM) returning a 0-length but otherwise full response

<small>Note: do not merge this with a merge commit. Do an FF merge if you need to but better yet leave this to me and I'll do it cleanly.</small>