### PR TITLE
Fix typos

### DIFF
--- a/http.md
+++ b/http.md
@@ -148,7 +148,7 @@ pass parameters like what port to use.
 
   -H --header [NAME: VALUE]...
 
-    Add the specified headers to all resposes.
+    Add the specified headers to all responses.
 
     VALUE is left-trimmed.
 
@@ -207,7 +207,7 @@ pass parameters like what port to use.
 
   -x --strip-extensions
 
-    Allow stripping index extentions from served paths:
+    Allow stripping index extensions from served paths:
     a request to /file might get served by /file.[s]htm[l].
 
     This is false by default

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1067,13 +1067,13 @@ impl HttpHandler {
     }
 
     fn handle_put_file(&self, req: &mut Request, req_p: PathBuf, legal: bool) -> IronResult<Response> {
-        let existant = !legal || req_p.exists();
+        let existent = !legal || req_p.exists();
         log!(self.log,
              "{} {} {magenta}{}{reset}, size: {}B",
              self.remote_addresses(&req),
              if !legal {
                  "tried to illegally create"
-             } else if existant {
+             } else if existent {
                  "replaced"
              } else {
                  "created"
@@ -1091,7 +1091,7 @@ impl HttpHandler {
             fs::copy(&temp_file_p, req_p).expect("Failed to copy temp file to requested file");
         }
 
-        Ok(Response::with((if !legal || !existant {
+        Ok(Response::with((if !legal || !existent {
                                status::Created
                            } else {
                                status::NoContent

--- a/src/options.rs
+++ b/src/options.rs
@@ -136,7 +136,7 @@ impl Options {
             .arg(Arg::from_usage("-l --no-listings 'Never generate dir listings. Default: false'"))
             .arg(Arg::from_usage("-i --no-indices 'Do not automatically use index files. Default: false'"))
             .arg(Arg::from_usage("-e --no-encode 'Do not encode filesystem files. Default: false'"))
-            .arg(Arg::from_usage("-x --strip-extensions 'Allow stripping index extentions from served paths. Default: false'"))
+            .arg(Arg::from_usage("-x --strip-extensions 'Allow stripping index extensions from served paths. Default: false'"))
             .arg(Arg::from_usage("-q --quiet... 'Suppress increasing amounts of output'"))
             .arg(Arg::from_usage("-c --no-colour 'Don't colourise the log output'"))
             .arg(Arg::from_usage("-d --webdav 'Handle WebDAV requests. Default: false'"))


### PR DESCRIPTION
Found via `codespell -L crate,clen`