### PR TITLE
Be explicit about when mutex guard is dropped.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -182,7 +182,7 @@ fn result_main() -> Result<(), Error> {
         })
         .unwrap();
     let mx = Mutex::new(());
-    let _ = end_handler.wait(mx.lock().unwrap()).unwrap();
+    drop(end_handler.wait(mx.lock().unwrap()).unwrap());
     responder.close().unwrap();
 
     // This is necessary because the server isn't Drop::drop()ped when the responder is


### PR DESCRIPTION
In Rust 1.65, https://github.com/rust-lang/rust/pull/97739 was merged, which adds a new lint against the pattern:
```
let _ = cond_var.wait(...).unwrap()
```
leading to:
```
error: non-binding let on a synchronization lock
   --> src/main.rs:185:9
    |
185 |     let _ = end_handler.wait(mx.lock().unwrap()).unwrap();
    |         ^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this binding will immediately drop the value assigned to it
    |         |
    |         this lock is not assigned to a binding and is immediately dropped
    |
    = note: `#[deny(let_underscore_lock)]` on by default
help: consider binding to an unused variable to avoid immediately dropping the value
    |
185 |     let _unused = end_handler.wait(mx.lock().unwrap()).unwrap();
    |         ~~~~~~~
help: consider immediately dropping the value
    |
185 |     drop(end_handler.wait(mx.lock().unwrap()).unwrap());
    |     ~~~~~                                             +

error: could not compile `https` due to previous error
```

This patch applies the second suggestion to be explicit about dropping the returned MutexGuard, which maintains the current behavior. (If the guard should live until the scope ends, I'll update this to use the first suggestion.)