### PR TITLE
Fix sync lock let binding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -182,7 +182,7 @@ fn result_main() -> Result<(), Error> {
         })
         .unwrap();
     let mx = Mutex::new(());
-    let _ = end_handler.wait(mx.lock().unwrap()).unwrap();
+    let _guard = end_handler.wait(mx.lock().unwrap()).unwrap();
     responder.close().unwrap();
 
     // This is necessary because the server isn't Drop::drop()ped when the responder is


### PR DESCRIPTION
Current master is rejected by rust 1.68.0:

```
    Checking https v1.12.5 (/foo/bar/http)
error: non-binding let on a synchronization lock
   --> src/main.rs:185:9
    |
185 |     let _ = end_handler.wait(mx.lock().unwrap()).unwrap();
    |         ^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this binding will immediately drop the value assigned to it
    |         |
    |         this lock is not assigned to a binding and is immediately dropped
    |
    = note: `#[deny(let_underscore_lock)]` on by default
help: consider binding to an unused variable to avoid immediately dropping the value
    |
185 |     let _unused = end_handler.wait(mx.lock().unwrap()).unwrap();
    |         ~~~~~~~
help: consider immediately dropping the value
    |
185 |     drop(end_handler.wait(mx.lock().unwrap()).unwrap());
    |     ~~~~~                                             +

error: could not compile `https` due to previous error
```

This is a simple patch for it.