### PR TITLE
Support BSDs by special-casing Linux and Android specifically

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,19 +1,19 @@
 extern crate embed_resource;
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 extern crate cc;
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::env;
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::io::Write;
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::path::Path;
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::fs::{self, File};
 
 
 /// The last line of this, after running it through a preprocessor, will expand to the value of `BLKGETSIZE`
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 static IOCTL_CHECK_SOURCE: &str = r#"
 #include <sys/mount.h>
 
@@ -21,7 +21,7 @@ BLKGETSIZE
 "#;
 
 /// Replace `{}` with the `BLKGETSIZE` expression from `IOCTL_CHECK_SOURCE`
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 static IOCTL_INCLUDE_SKELETON: &str = r#"
 /// Return `device size / 512` (`long *` arg)
 static BLKGETSIZE: {type} = {expr} as {type};
@@ -37,10 +37,10 @@ fn embed_resources() {
     embed_resource::compile("http-manifest.rc");
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn get_ioctl_data() {}
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_ioctl_data() {
     let ioctl_dir = Path::new(&env::var("OUT_DIR").unwrap()).join("ioctl-data");
     fs::create_dir_all(&ioctl_dir).unwrap();

--- a/src/util/os/non_windows_non_macos.rs
+++ b/src/util/os/non_windows_non_macos.rs
@@ -5,7 +5,7 @@ use std::fs::{FileType, Metadata};
 use std::ffi::CString;
 use std::path::Path;
 
-
+#[cfg(any(target_os = "linux", target_os = "android"))]
 include!(concat!(env!("OUT_DIR"), "/ioctl-data/ioctl.rs"));
 
 
@@ -30,6 +30,7 @@ pub fn file_length<P: AsRef<Path>>(meta: &Metadata, path: &P) -> u64 {
 }
 
 fn file_length_impl(meta: &Metadata, path: &Path) -> u64 {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     if is_device(&meta.file_type()) {
         let mut block_count: c_ulong = 0;
 


### PR DESCRIPTION
This is kind of gross, but at least gets the crate compiling on the BSDs that don't have an ioctl for querying block size. Solves #157.

To be honest I don't understand this code-base enough to know the "proper" fix. I'd like to understand why the ioctl is needed in the first place, instead of relying exclusively on `std::fs::MetaData::len` when that is present. This understand could help me to craft the "proper" patch for FreeBSD support.