### PR TITLE
Update traitobject to fix #154

### DIFF
--- a/vendor/hyper-0.10.16/Cargo.toml
+++ b/vendor/hyper-0.10.16/Cargo.toml
@@ -39,8 +39,7 @@ version = "1.0"
 version = "0.1"
 
 [dependencies.traitobject]
-git = "https://github.com/reem/rust-traitobject"
-rev = "b3471a15917b2caf5a8b27debb0b4b390fc6634f"
+version = "0.1.1"
 
 [dependencies.typeable]
 version = "0.1"


### PR DESCRIPTION
The problem with `traitobject` was fixed in version `0.1.1`.
Since `http` pinned the dependency to a git revision this was not picked up and the installation breaks on newer versions of Rust (see https://github.com/thecoshman/http/issues/154#issuecomment-2886391243).

This PR fixes this by depending on `0.1.1` instead. This version also includes the fix for `RUSTSEC-2020-0027`.