### PR TITLE
Parsed PUT timestamps, paste to upload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["network-programming", "web-programming::http-server"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml and the http-crates.io branch
-version = "2.4.0"
+version = "2.5.0"
 # Remember to also update in http.md
 authors = ["thecoshman <rust@thecoshman.com>",
            "nabijaczleweli <nabijaczleweli@nabijaczleweli.xyz>",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image:
   - Visual Studio 2022
 
-version: 2.4.0-{build}
+version: 2.5.0-{build}
 
 skip_tags: false
 
@@ -27,21 +27,21 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\http.exe http-v2.4.0.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note http-v2.4.0.exe
-  - makensis -DHTTP_VERSION=v2.4.0 install.nsi
+  - cp target\release\http.exe http-v2.5.0.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note http-v2.5.0.exe
+  - makensis -DHTTP_VERSION=v2.5.0 install.nsi
 
 test: off
 test_script:
   - cargo test --verbose --release
 
 artifacts:
-  - path: http-v2.4.0.exe
-  - path: http v2.4.0 installer.exe
+  - path: http-v2.5.0.exe
+  - path: http v2.5.0 installer.exe
 
 deploy:
   provider: GitHub
-  artifact: /http.*v2.4.0.*\.exe/
+  artifact: /http.*v2.5.0.*\.exe/
   auth_token:
     secure: ZTXvCrv9y01s7Hd60w8W7NaouPnPoaw9YJt9WhWQ2Pep8HLvCikt9Exjkz8SGP9P
   on:

--- a/assets/upload.js
+++ b/assets/upload.js
@@ -22,16 +22,26 @@ window.addEventListener("DOMContentLoaded", function() {
       return (ev.dataTransfer.types.contains || ev.dataTransfer.types.includes).call(ev.dataTransfer.types, el);
     })) {
       ev.preventDefault();
-
-      for(let i = ev.dataTransfer.files.length - 1; i >= 0; --i) {
-        if(!ev.dataTransfer.items[i].webkitGetAsEntry) {
-          let file = ev.dataTransfer.files[i];
-          upload_file(url + encodeURIComponent(file.name), file);
-        } else
-          recurse_upload(ev.dataTransfer.items[i].webkitGetAsEntry(), url);
-      }
+      process_transfer(ev.dataTransfer);
     }
   });
+
+  body.addEventListener("paste", function(ev) {
+    if(ev.target.tagName != "INPUT" && (ev.clipboardData || window.clipboardData).files.length) {
+      ev.preventDefault();
+      process_transfer(ev.clipboardData || window.clipboardData);
+    }
+  });
+
+  function process_transfer(transfer) {
+    for(let i = transfer.files.length - 1; i >= 0; --i) {
+      if(!transfer.items[i].webkitGetAsEntry) {
+        let file = transfer.files[i];
+        upload_file(url + encodeURIComponent(file.name), file);
+      } else
+        recurse_upload(transfer.items[i].webkitGetAsEntry(), url);
+    }
+  }
 
   let file_upload = document.querySelector("input[type=file]");
   let upload_list = document.createElement("dl");

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1177,7 +1177,7 @@ impl HttpHandler {
                                                                        list_f,
                                                                        if show_file_management_controls {
                                                                            "<hr />\
-                                                                            <p>Drag&amp;Drop to upload or <input type=\"file\" multiple />.</p>"
+                                                                            <p>Upload via drag&drop, paste, or <input type=\"file\" multiple />.</p>"
                                                                        } else {
                                                                            ""
                                                                        },

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -26,11 +26,12 @@ use iron::{headers, status, method, IronResult, Listening, Response, Headers, Re
 use std::io::{self, ErrorKind as IoErrorKind, BufReader, SeekFrom, Write, Error as IoError, Read, Seek};
 use iron::mime::{Mime, Attr as MimeAttr, Value as MimeAttrValue, SubLevel as MimeSubLevel, TopLevel as MimeTopLevel};
 use self::super::util::{HumanReadableSize, WwwAuthenticate, NoDoubleQuotes, NoHtmlLiteral, XLastModified, DisplayThree, CommaList,
-                        XOcMTime, MsAsS, Maybe, Dav, url_path, file_etag, file_hash, set_mtime_f, is_symlink, encode_str, error_html, encode_file, file_length,
-                        file_binary, client_mobile, percent_decode, escape_specials, precise_time_ns, file_icon_suffix, is_actually_file, is_descendant_of,
-                        response_encoding, detect_file_as_dir, encoding_extension, file_time_modified, file_time_modified_p, dav_level_1_methods,
-                        get_raw_fs_metadata, encode_tail_if_trimmed, extension_is_blacklisted, directory_listing_html, directory_listing_mobile_html,
-                        is_nonexistent_descendant_of, USER_AGENT, MAX_SYMLINKS, INDEX_EXTENSIONS, MIN_ENCODING_GAIN, MAX_ENCODING_SIZE, MIN_ENCODING_SIZE};
+                        XOcMTime, MsAsSAnd3339, Maybe, Dav, url_path, file_etag, file_hash, set_mtime_f, is_symlink, encode_str, error_html, encode_file,
+                        file_length, file_binary, client_mobile, percent_decode, escape_specials, precise_time_ns, file_icon_suffix, is_actually_file,
+                        is_descendant_of, response_encoding, detect_file_as_dir, encoding_extension, file_time_modified, file_time_modified_p,
+                        dav_level_1_methods, get_raw_fs_metadata, encode_tail_if_trimmed, extension_is_blacklisted, directory_listing_html,
+                        directory_listing_mobile_html, is_nonexistent_descendant_of, USER_AGENT, MAX_SYMLINKS, INDEX_EXTENSIONS, MIN_ENCODING_GAIN,
+                        MAX_ENCODING_SIZE, MIN_ENCODING_SIZE};
 
 macro_rules! log {
     ($logcfg:expr, $fmt:expr) => {{
@@ -1275,7 +1276,7 @@ impl HttpHandler {
              req_p.display(),
              *req.headers.get::<headers::ContentLength>().expect("No Content-Length header"),
              mtime.map_or("", |_| ". modified: "),
-             Maybe(mtime.map(MsAsS)));
+             Maybe(mtime.map(MsAsSAnd3339)));
 
         let mut ibuf = BufReader::with_capacity(1024 * 1024, &mut req.body);
         let file = match direct_output {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,13 +10,13 @@ use percent_encoding;
 use walkdir::WalkDir;
 use std::borrow::Cow;
 use rfsapi::RawFileData;
-use chrono::{DateTime, Utc};
 use iron::{mime, Headers, Url};
 use std::{cmp, fmt, f64, mem, str};
 use mime_guess::guess_mime_type_opt;
 use std::time::{SystemTime, Instant};
 use std::fs::{self, FileType, Metadata, File};
 use iron::headers::{HeaderFormat, UserAgent, Header};
+use chrono::{DateTime, TimeZone, Utc, Local as LocalTz};
 use xml::name::{OwnedName as OwnedXmlName, Name as XmlName};
 use iron::error::{HttpResult as HyperResult, HttpError as HyperError};
 use iron::mime::{Mime, SubLevel as MimeSubLevel, TopLevel as MimeTopLevel};
@@ -251,11 +251,15 @@ impl<T: fmt::Display> fmt::Display for Maybe<T> {
 }
 
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
-pub struct MsAsS(pub u64);
+pub struct MsAsSAnd3339(pub u64);
 
-impl fmt::Display for MsAsS {
+impl fmt::Display for MsAsSAnd3339 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}.{:03}", self.0 / 1000, self.0 % 1000)
+        write!(f,
+               "@{}.{:03}{}",
+               self.0 / 1000,
+               self.0 % 1000,
+               Maybe(LocalTz.timestamp_millis_opt(self.0 as _).earliest().map(|ts| DisplayThree(" (", ts, ")"))))
     }
 }
 


### PR DESCRIPTION
1. ```
   Before: [2025-11-09 17:34:44] 192.168.1.109:7850 replaced \\?\T:\temp\kill-mupd.log, size: 1753645B. modified: 1762705928.187
   After:  [2025-11-09 17:34:44] 192.168.1.109:7850 replaced \\?\T:\temp\kill-mupd.log, size: 1753645B. modified: 1762705928.187 (2025-11-09 17:32:08.187 +01:00)
   ```
   and
   ```
   Before: [2025-11-09 18:17:53] 192.168.1.109:8682 created /home/nabijaczleweli/code/http/image.png, size: 86255B. modified: 1762708664.032
   After:  [2025-11-09 18:17:53] 192.168.1.109:8682 created /home/nabijaczleweli/code/http/image.png, size: 86255B. modified: @1762708664.032 (2025-11-09 18:17:44.032 +01:00)
   ```
   both formats are understood by date(1)
2. On generated indices where you could drag&drop, you can also paste now